### PR TITLE
fix: clear the right Python stack before unwinding

### DIFF
--- a/echion/stacks.h
+++ b/echion/stacks.h
@@ -91,7 +91,7 @@ unwind_python_stack(PyThreadState *tstate, FrameStack &stack)
 {
     std::unordered_set<void *> seen_frames; // Used to detect cycles in the stack
 
-    python_stack.clear();
+    stack.clear();
 
 #if PY_VERSION_HEX >= 0x030b0000
     _PyCFrame cframe;


### PR DESCRIPTION
The wrong stack was being cleared after a refactor where the stack to hold the frame was changed to allow to be passed in as an argument.