### PR TITLE
fix(linux): acquire CPU clock ID on thread tracking

### DIFF
--- a/echion/coremodule.cc
+++ b/echion/coremodule.cc
@@ -119,7 +119,9 @@ static void for_each_thread(std::function<void(PyThreadState *, ThreadInfo *)> c
                 new_info->native_id = getpid();
 #endif
 
-#if defined PL_DARWIN
+#if defined PL_LINUX
+                pthread_getcpuclockid((pthread_t)tstate.thread_id, &new_info->cpu_clock_id);
+#elif defined PL_DARWIN
                 pthread_threadid_np((pthread_t)tstate.thread_id, (__uint64_t *)&new_info->native_id);
                 new_info->mach_port = pthread_mach_thread_np((pthread_t)tstate.thread_id);
 #endif
@@ -470,7 +472,9 @@ track_thread(PyObject *Py_UNUSED(m), PyObject *args)
         info->thread_id = thread_id;
         info->name = name;
         info->native_id = native_id;
-#if defined PL_DARWIN
+#if defined PL_LINUX
+        pthread_getcpuclockid((pthread_t)thread_id, &info->cpu_clock_id);
+#elif defined PL_DARWIN
         info->mach_port = pthread_mach_thread_np((pthread_t)thread_id);
 #endif
         info->update_cpu_time();

--- a/echion/threads.h
+++ b/echion/threads.h
@@ -24,7 +24,9 @@ public:
     uintptr_t thread_id;
     unsigned long native_id;
     const char *name;
-#if defined PL_DARWIN
+#if defined PL_LINUX
+    clockid_t cpu_clock_id;
+#elif defined PL_DARWIN
     mach_port_t mach_port;
 #endif
     microsecond_t cpu_time;
@@ -43,12 +45,8 @@ public:
 void ThreadInfo::update_cpu_time()
 {
 #if defined PL_LINUX
-    clockid_t cid;
-    if (pthread_getcpuclockid((pthread_t)this->thread_id, &cid))
-        return;
-
     struct timespec ts;
-    if (clock_gettime(cid, &ts))
+    if (clock_gettime(cpu_clock_id, &ts))
         return;
 
     this->cpu_time = TS_TO_MICROSECOND(ts);


### PR DESCRIPTION
Acquiring the CPU clock ID requires a pthread_t, which might become unavaiable if the ID is being retrieved with every update. Since the tracking happens with the GIL, that is the best time to grab the clock ID and store it for future use.