### PR TITLE
fix: memory leak in Python bytes object retrieval

### DIFF
--- a/echion/cpython/tasks.h
+++ b/echion/cpython/tasks.h
@@ -193,7 +193,7 @@ extern "C"
                 return NULL;
 
             Py_ssize_t s = 0;
-            unsigned char *c = (unsigned char *)pybytes_to_bytes_and_size(code.co_code, &s);
+            auto c = pybytes_to_bytes_and_size(code.co_code, &s);
 
             if (c[(frame.f_lasti + 1) * sizeof(_Py_CODEUNIT)] != YIELD_FROM)
                 return NULL;
@@ -233,7 +233,7 @@ extern "C"
                 return NULL;
 
             Py_ssize_t s = 0;
-            unsigned char *c = (unsigned char *)pybytes_to_bytes_and_size(code.co_code, &s);
+            auto c = pybytes_to_bytes_and_size(code.co_code, &s);
 
             if (c[f->f_lasti + sizeof(_Py_CODEUNIT)] != YIELD_FROM)
                 return NULL;

--- a/echion/strings.h
+++ b/echion/strings.h
@@ -15,24 +15,21 @@
 #include <echion/vm.h>
 
 // ----------------------------------------------------------------------------
-static char *
+static std::unique_ptr<unsigned char[]>
 pybytes_to_bytes_and_size(PyObject *bytes_addr, Py_ssize_t *size)
 {
     PyBytesObject bytes;
 
     if (copy_type(bytes_addr, bytes))
-        return NULL;
+        return nullptr;
 
     *size = bytes.ob_base.ob_size;
     if (*size < 0 || *size > (1 << 20))
-        return NULL;
+        return nullptr;
 
-    char *data = new char[*size];
-    if (copy_generic(((char *)bytes_addr) + offsetof(PyBytesObject, ob_sval), data, *size))
-    {
-        delete[] data;
-        return NULL;
-    }
+    auto data = std::make_unique<unsigned char[]>(*size);
+    if (copy_generic(((char *)bytes_addr) + offsetof(PyBytesObject, ob_sval), data.get(), *size))
+        return nullptr;
 
     return data;
 }


### PR DESCRIPTION
Fixed a memory leak when retrieving byte arrays (line number tables) that were never deallocated after use. We move to automatic memory management with smart pointers to allow for the clean up to happen.