### PR TITLE
fix: task link origin lookup

### DIFF
--- a/echion/threads.h
+++ b/echion/threads.h
@@ -273,7 +273,9 @@ void ThreadInfo::unwind_tasks()
                 // Check for, e.g., gather links
                 std::lock_guard<std::mutex> lock(task_link_map_lock);
 
-                if (task_link_map.find(task_origin) != task_link_map.end())
+                if (
+                    task_link_map.find(task_origin) != task_link_map.end() &&
+                    origin_map.find(task_link_map[task_origin]) != origin_map.end())
                 {
                     current_task = origin_map.find(task_link_map[task_origin])->second;
                     continue;


### PR DESCRIPTION
Ensure that we actually have the origin in the origin map before attempting to dereference it. Since we do not hold the task link map lock for longer than we need, the trade-off for performance is a potential loss os sync with the data collected in earlier stages of the unwind_tasks method. Therefore we do not make the assumption that the lookup is always successful to prevent potential invalid memory dereferencing.