### PR TITLE
fix: guard allocation size

### DIFF
--- a/echion/cpython/tasks.h
+++ b/echion/cpython/tasks.h
@@ -162,6 +162,9 @@ extern "C"
             if (!(_Py_OPCODE(next) == RESUME || _Py_OPCODE(next) == RESUME_QUICK) || _Py_OPARG(next) < 2)
                 return NULL;
 
+            if (frame.stacktop < 1 || frame.stacktop > (1 << 20))
+                return NULL;
+
             auto localsplus = std::make_unique<PyObject *[]>(frame.stacktop);
             if (copy_generic(frame.localsplus, localsplus.get(), frame.stacktop * sizeof(PyObject *)))
                 return NULL;
@@ -201,7 +204,11 @@ extern "C"
                 return NULL;
 
             ssize_t nvalues = frame.f_stackdepth;
+            if (nvalues < 1 || nvalues > (1 << 20))
+                return NULL;
+
             auto stack = std::make_unique<PyObject *[]>(nvalues);
+
             if (copy_generic(frame.f_valuestack, stack.get(), nvalues * sizeof(PyObject *)))
                 return NULL;
 

--- a/echion/mirrors.h
+++ b/echion/mirrors.h
@@ -109,7 +109,10 @@ MirrorDict::MirrorDict(PyObject *dict_addr)
     size_t values_size = dict.ma_values != NULL ? keys.dk_nentries * sizeof(PyObject *) : 0;
 
     // Allocate the buffer
-    size_t data_size = keys_size + (keys.dk_nentries * entry_size) + values_size;
+    ssize_t data_size = keys_size + (keys.dk_nentries * entry_size) + values_size;
+    if (data_size < 0 || data_size > (1 << 20))
+        throw MirrorError();
+
     data = std::make_unique<char[]>(data_size);
 
     // Copy the key data and update the pointer
@@ -149,7 +152,10 @@ MirrorSet::MirrorSet(PyObject *set_addr)
         throw MirrorError();
 
     size = set.mask + 1;
-    size_t table_size = size * sizeof(setentry);
+    ssize_t table_size = size * sizeof(setentry);
+    if (table_size < 0 || table_size > (1 << 20))
+        throw MirrorError();
+
     data = std::make_unique<char[]>(table_size);
     if (copy_generic(set.table, data.get(), table_size))
         throw MirrorError();


### PR DESCRIPTION
When allocating memory using a size value read from copied memory, we make sure that the value is sensible before attempting the allocation.