### PR TITLE
fix: manage global variables lifetime

### DIFF
--- a/echion/frame.h
+++ b/echion/frame.h
@@ -311,16 +311,19 @@ Frame::Frame(unw_word_t pc, const char *name, unw_word_t offset)
 static Frame INVALID_FRAME("<invalid>");
 static Frame UNKNOWN_FRAME("<unknown>");
 
-static std::unique_ptr<LRUCache<uintptr_t, Frame>> frame_cache = nullptr;
+// We make this a raw pointer to prevent its destruction on exit, since we
+// control the lifetime of the cache.
+static LRUCache<uintptr_t, Frame> *frame_cache = nullptr;
 
 static void init_frame_cache(size_t capacity)
 {
-    frame_cache = std::make_unique<LRUCache<uintptr_t, Frame>>(capacity);
+    frame_cache = new LRUCache<uintptr_t, Frame>(capacity);
 }
 
 static void reset_frame_cache()
 {
-    frame_cache.reset();
+    delete frame_cache;
+    frame_cache = nullptr;
 }
 
 Frame &Frame::get(PyCodeObject *code_addr, int lasti)

--- a/echion/threads.h
+++ b/echion/threads.h
@@ -155,7 +155,12 @@ bool ThreadInfo::is_running()
 
 // ----------------------------------------------------------------------------
 
-static std::unordered_map<uintptr_t, ThreadInfo::Ptr> thread_info_map; // indexed by thread_id
+// We make this a reference to a heap-allocated object so that we can avoid
+// the destruction on exit. We are in charge of cleaning up the object. Note
+// that the object will leak, but this is not a problem.
+static std::unordered_map<uintptr_t, ThreadInfo::Ptr> &thread_info_map =
+    *(new std::unordered_map<uintptr_t, ThreadInfo::Ptr>()); // indexed by thread_id
+
 static std::mutex thread_info_map_lock;
 
 // ----------------------------------------------------------------------------


### PR DESCRIPTION
The lifetime of some global variables is managed manually. Automatic management done on exit can race with the one done manually, causing issues such as double free.