### PR TITLE
chore: introduce a string table

### DIFF
--- a/echion/coremodule.cc
+++ b/echion/coremodule.cc
@@ -117,6 +117,7 @@ _stop()
         const std::lock_guard<std::mutex> guard(thread_info_map_lock);
 
         thread_info_map.clear();
+        string_table.clear();
     }
 
 #if defined PL_DARWIN

--- a/echion/tasks.h
+++ b/echion/tasks.h
@@ -133,7 +133,7 @@ public:
 
     GenInfo::Ptr coro = nullptr;
 
-    std::string name;
+    StringTable::Key name;
 
     // Information to reconstruct the async stack as best as we can
     TaskInfo::Ptr waiter = nullptr;
@@ -167,17 +167,9 @@ TaskInfo::TaskInfo(TaskObj *task_addr)
 
     try
     {
-#if PY_VERSION_HEX >= 0x030c0000
-        // The task name might hold a PyLong for deferred task name formatting.
-        PyLongObject name_obj;
-        name = (!copy_type(task.task_name, name_obj) && PyLong_CheckExact(&name_obj))
-                   ? "Task-" + std::to_string(PyLong_AsLong((PyObject *)&name_obj))
-                   : pyunicode_to_utf8(task.task_name);
-#else
-        name = pyunicode_to_utf8(task.task_name);
-#endif
+        name = string_table.key(task.task_name);
     }
-    catch (StringError &)
+    catch (StringTable::Error &)
     {
         throw Error();
     }

--- a/echion/threads.h
+++ b/echion/threads.h
@@ -279,7 +279,7 @@ void ThreadInfo::unwind_tasks()
             }
 
             // Add the task name frame
-            stack->push_back(Frame::get(task.origin, task.name));
+            stack->push_back(Frame::get(task.name));
 
             // Get the next task in the chain
             PyObject *task_origin = task.origin;


### PR DESCRIPTION
We introduce a string table to centralise the handling of strings used for frame information. This is an intermediate step to get to implementing support for the MOJO binary format for data compression.