### PR TITLE
chore: remove unused init in interpreter unwinding

### DIFF
--- a/echion/interp.h
+++ b/echion/interp.h
@@ -21,7 +21,6 @@
 static void for_each_interp(std::function<void(PyInterpreterState *interp)> callback)
 {
     PyInterpreterState interp;
-    PyInterpreterState *interp_addr = runtime->interpreters.head;
     for (PyInterpreterState *interp_addr = runtime->interpreters.head;
          !copy_type(interp_addr, interp);
          interp_addr = interp.next)


### PR DESCRIPTION
Driveby fix