### PR TITLE
Add `pylong_to_llong()`

### DIFF
--- a/echion/long.h
+++ b/echion/long.h
@@ -1,0 +1,46 @@
+// This file is part of "echion" which is released under MIT.
+//
+// Copyright (c) 2023 Gabriele N. Tornetta <phoenix1987@gmail.com>.
+#pragma once
+
+#include <Python.h>
+#if PY_VERSION_HEX >= 0x030c0000
+#include <internal/pycore_long.h>
+#endif
+
+#include <exception>
+
+class LongError : public std::exception {
+  const char *what() const noexcept override { return "LongError"; }
+};
+
+// ----------------------------------------------------------------------------
+#if PY_VERSION_HEX >= 0x030c0000
+static long long pylong_to_llong(PyObject *long_addr) {
+  // Only used to extract a task-id on Python 3.12, omits overflow checks
+  PyLongObject long_obj;
+  long long ret = 0;
+
+  if (copy_type(long_addr, long_obj))
+    throw LongError();
+
+  if (!PyLong_CheckExact(&long_obj))
+    throw LongError();
+
+  if (_PyLong_IsCompact(&long_obj)) {
+    ret = (long long)_PyLong_CompactValue(&long_obj);
+  } else {
+    // If we're here, then we need to iterate over the digits
+    // We might overflow, but we don't care for now
+    int sign = _PyLong_NonCompactSign(&long_obj);
+    Py_ssize_t i = _PyLong_DigitCount(&long_obj);
+    while (--i >= 0) {
+      ret <<= PyLong_SHIFT;
+      ret |= long_obj.long_value.ob_digit[i];
+    }
+    ret *= sign;
+  }
+
+  return ret;
+}
+#endif

--- a/echion/strings.h
+++ b/echion/strings.h
@@ -12,6 +12,7 @@
 #include <exception>
 #include <string>
 
+#include <echion/long.h>
 #include <echion/vm.h>
 
 class StringError : public std::exception

--- a/echion/strings.h
+++ b/echion/strings.h
@@ -99,10 +99,15 @@ public:
             {
 #if PY_VERSION_HEX >= 0x030c0000
                 // The task name might hold a PyLong for deferred task name formatting.
-                PyLongObject l;
-                auto str = (!copy_type(s, l) && PyLong_CheckExact(&l))
-                               ? "Task-" + std::to_string(PyLong_AsLong((PyObject *)&l))
-                               : pyunicode_to_utf8(s);
+                std::string str = "Task-";
+                try
+                {
+                  str += std::to_string(pylong_to_llong(s));
+                }
+                catch (LongError &)
+                {
+                  str = pyunicode_to_utf8(s);
+                }
 #else
                 auto str = pyunicode_to_utf8(s);
 #endif


### PR DESCRIPTION
`pylong_to_llong()` is a helper function to extract task id for CPython versions 3.12+ 