### PR TITLE
Add preprocessor checks for UNWIND_NATIVE_DISABLE

### DIFF
--- a/echion/config.h
+++ b/echion/config.h
@@ -79,7 +79,9 @@ set_native(PyObject *Py_UNUSED(m), PyObject *args)
 
     native = new_native;
 #else
-    PyErr_SetString(PyExc_RuntimeError, "Native profiling is disabled, please re-build/install echion without UNWIND_NATIVE_DISABLE env var");
+    PyErr_SetString(PyExc_RuntimeError,
+        "Native profiling is disabled, please re-build/install echion without "
+        "UNWIND_NATIVE_DISABLE env var/preprocessor flag");
     return NULL;
 #endif // UNWIND_NATIVE_DISABLE
     Py_RETURN_NONE;

--- a/echion/config.h
+++ b/echion/config.h
@@ -72,12 +72,16 @@ set_memory(PyObject *Py_UNUSED(m), PyObject *args)
 static PyObject *
 set_native(PyObject *Py_UNUSED(m), PyObject *args)
 {
+#ifndef UNWIND_NATIVE_DISABLE
     int new_native;
     if (!PyArg_ParseTuple(args, "p", &new_native))
         return NULL;
 
     native = new_native;
-
+#else
+    PyErr_SetString(PyExc_RuntimeError, "Native profiling is disabled, please re-build/install echion without UNWIND_NATIVE_DISABLE env var");
+    return NULL;
+#endif // UNWIND_NATIVE_DISABLE
     Py_RETURN_NONE;
 }
 

--- a/echion/frame.h
+++ b/echion/frame.h
@@ -21,9 +21,11 @@
 #include <functional>
 #include <iostream>
 
+#ifndef UNWIND_NATIVE_DISABLE
 #include <cxxabi.h>
 #define UNW_LOCAL_ONLY
 #include <libunwind.h>
+#endif // UNWIND_NATIVE_DISABLE
 
 #include <echion/cache.h>
 #include <echion/mojo.h>
@@ -112,7 +114,9 @@ public:
 
     static Frame &get(PyCodeObject *code_addr, int lasti);
     static Frame &get(PyObject *frame);
+#ifndef UNWIND_NATIVE_DISABLE
     static Frame &get(unw_cursor_t &cursor);
+#endif // UNWIND_NATIVE_DISABLE
     static Frame &get(StringTable::Key name);
 
     // ------------------------------------------------------------------------
@@ -170,6 +174,7 @@ public:
     }
 
     // ------------------------------------------------------------------------
+#ifndef UNWIND_NATIVE_DISABLE
     Frame(unw_cursor_t &cursor, unw_word_t pc)
     {
         try
@@ -182,6 +187,7 @@ public:
             throw Error();
         }
     }
+#endif // UNWIND_NATIVE_DISABLE
 
     // ------------------------------------------------------------------------
     void render_where(std::ostream &stream)
@@ -501,6 +507,7 @@ Frame &Frame::get(PyObject *frame)
 }
 
 // ----------------------------------------------------------------------------
+#ifndef UNWIND_NATIVE_DISABLE
 Frame &Frame::get(unw_cursor_t &cursor)
 {
     unw_word_t pc;
@@ -535,6 +542,7 @@ Frame &Frame::get(unw_cursor_t &cursor)
         }
     }
 }
+#endif // UNWIND_NATIVE_DISABLE
 
 // ----------------------------------------------------------------------------
 Frame &Frame::get(StringTable::Key name)

--- a/echion/signals.h
+++ b/echion/signals.h
@@ -19,7 +19,9 @@ static std::mutex sigprof_handler_lock;
 // ----------------------------------------------------------------------------
 void sigprof_handler([[maybe_unused]] int signum)
 {
+#ifndef UNWIND_NATIVE_DISABLE
     unwind_native_stack();
+#endif // UNWIND_NATIVE_DISABLE
     unwind_python_stack(current_tstate);
     // NOTE: Native stacks for tasks is non-trivial, so we skip it for now.
 

--- a/echion/signals.h
+++ b/echion/signals.h
@@ -49,5 +49,7 @@ void install_signals()
 void restore_signals()
 {
     signal(SIGQUIT, SIG_DFL);
-    signal(SIGPROF, SIG_DFL);
+
+    if (native)
+        signal(SIGPROF, SIG_DFL);
 }

--- a/echion/stacks.h
+++ b/echion/stacks.h
@@ -12,8 +12,10 @@
 #include <unordered_map>
 #include <unordered_set>
 
+#ifndef UNWIND_NATIVE_DISABLE
 #define UNW_LOCAL_ONLY
 #include <libunwind.h>
+#endif // UNWIND_NATIVE_DISABLE
 
 #include <echion/frame.h>
 #include <echion/mojo.h>
@@ -66,6 +68,7 @@ static FrameStack native_stack;
 static FrameStack interleaved_stack;
 
 // ----------------------------------------------------------------------------
+#ifndef UNWIND_NATIVE_DISABLE
 void unwind_native_stack()
 {
     unw_cursor_t cursor;
@@ -88,6 +91,7 @@ void unwind_native_stack()
         }
     }
 }
+#endif // UNWIND_NATIVE_DISABLE
 
 // ----------------------------------------------------------------------------
 static size_t

--- a/echion/strings.h
+++ b/echion/strings.h
@@ -146,6 +146,7 @@ public:
         return k;
     };
 
+#ifndef UNWIND_NATIVE_DISABLE
     // Native filename by program counter
     inline Key key(unw_word_t pc)
     {
@@ -206,6 +207,7 @@ public:
 
         return k;
     }
+#endif // UNWIND_NATIVE_DISABLE
 
     inline std::string &lookup(Key key)
     {

--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,7 @@
 #
 # Copyright (c) 2023 Gabriele N. Tornetta <phoenix1987@gmail.com>.
 
+import os
 import sys
 from pathlib import Path
 
@@ -12,8 +13,10 @@ from setuptools import setup
 
 PLATFORM = sys.platform.lower()
 
+DISABLE_NATIVE = os.environ.get("UNWIND_NATIVE_DISABLE")
+
 LDADD = {
-    "linux": ["-l:libunwind.a", "-l:liblzma.a"],
+    "linux": ["-l:libunwind.a", "-l:liblzma.a"] if not DISABLE_NATIVE else [],
 }
 
 # add option to colorize compiler output
@@ -25,6 +28,9 @@ if PLATFORM == "darwin":
     CFLAGS = ["-mmacosx-version-min=10.15"]
 else:
     CFLAGS = []
+
+if DISABLE_NATIVE:
+    CFLAGS += ["-DUNWIND_NATIVE_DISABLE"]
 
 echionmodule = Extension(
     "echion.core",


### PR DESCRIPTION
When `UNWIND_NATIVE_DISABLE` is set, libunwind and liblzma is not needed to compile echion. 