### PR TITLE
Add a `safe_copy()` alternative for linux using `writev()`

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,7 @@ jobs:
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
         echion-alt-vm-force: ["1", "0"]
 
-    name: Tests with Python ${{ matrix.python-version }}, ECHION_ALT_VM_FORCE=${{ echion-alt-vm-force }} on ubuntu-latest
+    name: Tests with Python ${{ matrix.python-version }}, ECHION_ALT_VM_FORCE=${{ matrix.echion-alt-vm-force }} on ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,7 @@ jobs:
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
         echion-alt-vm-force: ["1", "0"]
 
-    name: Tests with Python ${{ matrix.python-version }} on ubuntu-latest
+    name: Tests with Python ${{ matrix.python-version }}, ECHION_ALT_VM_FORCE=${{ echion-alt-vm-force }} on ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,6 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+        echion-alt-vm-force: ["1", "0"]
 
     name: Tests with Python ${{ matrix.python-version }} on ubuntu-latest
     steps:
@@ -40,7 +41,7 @@ jobs:
         run: |
           ulimit -c unlimited
           echo "core.%p" | sudo tee /proc/sys/kernel/core_pattern
-          sudo -E env PATH="$PATH" hatch run tests.py${{ matrix.python-version }}:tests -svv
+          sudo -E env PATH="$PATH" ECHION_ALT_VM_READ_FORCE=${{ matrix.echion-alt-vm-force }} hatch run tests.py${{ matrix.python-version }}:tests -svv
 
       - name: Print core dumps
         run: |

--- a/echion/vm.h
+++ b/echion/vm.h
@@ -52,8 +52,8 @@ ssize_t (*safe_copy)(pid_t, const struct iovec *, unsigned long, const struct io
 
 class VmReader
 {
-    void *buffer;
-    size_t sz;
+    void *buffer{nullptr};
+    size_t sz{0};
     int fd{-1};
     inline static VmReader *instance{nullptr}; // Prevents having to set this in implementation
 

--- a/echion/vm.h
+++ b/echion/vm.h
@@ -4,10 +4,20 @@
 
 #pragma once
 
+#include <iostream>
+#include <array>
+#include <string>
+#include <stdexcept>
+#include <cstdlib>
+
 #if defined PL_LINUX
+#include <algorithm>
 #include <sys/uio.h>
 #include <sys/types.h>
 #include <unistd.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <sys/mman.h>
 
 typedef pid_t proc_ref_t;
 
@@ -33,6 +43,176 @@ typedef mach_port_t proc_ref_t;
 #define copy_generic(addr, dest, size) (copy_memory(mach_task_self(), (void *)(addr), size, (void *)(dest)))
 #endif
 
+// Some checks are done at static initialization, so use this to read them at runtime
+bool failed_safe_copy = false;
+
+#if defined PL_LINUX
+ssize_t (*safe_copy)(pid_t, const struct iovec *, unsigned long, const struct iovec *, unsigned long, unsigned long) = process_vm_readv;
+
+class VmReader {
+  void *buffer;
+  size_t sz;
+  int fd{-1};
+  inline static VmReader *instance{nullptr};  // Prevents having to set this in implementation
+
+  void* init(size_t new_sz) {
+    // Makes a temporary file and ftruncates it to the specified size
+    std::array<std::string, 3> tmp_dirs= {"/dev/shm", "/tmp", "/var/tmp"};
+    std::string tmp_suffix = "/echion-XXXXXX";
+    void* ret = nullptr;
+
+    for (auto &tmp_dir : tmp_dirs) {
+      // Reset the file descriptor, just in case
+      close(fd);
+      fd = -1;
+
+      // Create the temporary file
+      std::string tmpfile = tmp_dir + tmp_suffix;
+      fd = mkstemp(tmpfile.data());
+      if (fd == -1)
+        continue;
+
+      // Unlink might fail if delete is blocked on the VFS, but currently no action is taken
+      unlink(tmpfile.data());
+
+      // Make sure we have enough size
+      if (ftruncate(fd, new_sz) == -1) {
+        continue;
+      }
+
+      // Map the file
+      ret = mmap(NULL, new_sz, PROT_READ | PROT_WRITE, MAP_PRIVATE, fd, 0);
+      if (ret == MAP_FAILED) {
+        ret = nullptr;
+        continue;
+      }
+
+      // Successful.  Break.
+      sz = new_sz;
+      break;
+    }
+
+    return ret;
+  }
+
+  VmReader(size_t _sz) : sz{_sz} {
+    buffer = init(sz);
+    if (!buffer) {
+      throw std::runtime_error("Failed to initialize VmReader");
+    }
+    instance = this;
+  }
+
+
+public:
+  static VmReader *get_instance() {
+    if (instance == nullptr) {
+      try {
+        instance = new VmReader(1024 * 1024); // A megabyte?
+      } catch (std::exception &e) {
+        std::cerr << "Failed to initialize VmReader: " << e.what() << std::endl;
+      }
+    }
+    return instance;
+  }
+
+  ssize_t safe_copy(pid_t pid,
+                    const struct iovec *local_iov, unsigned long liovcnt,
+                    const struct iovec *remote_iov, unsigned long riovcnt, unsigned long flags) {
+    (void)pid;
+    (void)flags;
+    if (liovcnt != 1 || riovcnt != 1) {
+      // Unsupported
+      return 0;
+    }
+
+    // Check to see if we need to resize the buffer
+    if (remote_iov[0].iov_len > sz) {
+      if (ftruncate(fd, remote_iov[0].iov_len) == -1) {
+        return 0;
+      } else {
+        void *tmp = mremap(buffer, sz, remote_iov[0].iov_len, MREMAP_MAYMOVE);
+        if (tmp == MAP_FAILED) {
+          return 0;
+        }
+        buffer = tmp; // no need to munmap
+        sz = remote_iov[0].iov_len;
+      }
+    }
+
+    ssize_t ret = pwritev(fd, remote_iov, riovcnt, 0);
+    if (ret == -1) {
+      return ret;
+    }
+
+    // Copy the data from the buffer to the remote process
+    memcpy(local_iov[0].iov_base, buffer, local_iov[0].iov_len);
+    return ret;
+  }
+
+  ~VmReader() {
+    munmap(buffer, sz);
+    instance = nullptr;
+  }
+};
+
+/**
+  * Initialize the safe copy operation on Linux
+  */
+bool read_process_vm_init() {
+  VmReader *_ = VmReader::get_instance();
+  return !!_;
+}
+
+ssize_t vmreader_safe_copy(pid_t pid,
+                       const struct iovec *local_iov, unsigned long liovcnt,
+                       const struct iovec *remote_iov, unsigned long riovcnt, unsigned long flags) {
+  auto reader = VmReader::get_instance();
+  if (!reader)
+    return 0;
+  return reader->safe_copy(pid, local_iov, liovcnt, remote_iov, riovcnt, flags);
+}
+
+/**
+ * Initialize the safe copy operation on Linux
+ *
+ * This occurs at static init
+ */
+__attribute__((constructor)) void init_safe_copy() {
+  char src[128];
+  char dst[128];
+  for (size_t i = 0; i < 128; i++) {
+    src[i] = 0x41;
+    dst[i] = ~0x42;
+  }
+
+  // Check to see that process_vm_readv works, unless it's overridden
+  const char force_override_str[] = "ECHION_ALT_VM_READ_FORCE";
+  const std::array<std::string, 6> truthy_values = {"1", "true", "yes", "on", "enable", "enabled"};
+  const char* force_override = std::getenv(force_override_str);
+  if (!force_override || std::find(truthy_values.begin(), truthy_values.end(), force_override) == truthy_values.end()) {
+    struct iovec iov_dst = {dst, sizeof(dst)};
+    struct iovec iov_src = {src, sizeof(src)};
+    ssize_t result = process_vm_readv(getpid(), &iov_dst, 1, &iov_src, 1, 0);
+
+    // If we succeed, then use process_vm_readv
+    if (result == sizeof(src)) {
+      safe_copy = process_vm_readv;
+      return;
+    }
+  }
+
+  // Else, we have to setup the writev method
+  if (!read_process_vm_init()) {
+    std::cerr << "Failed to initialize all safe copy interfaces" << std::endl;
+    failed_safe_copy = true;
+    return;
+  }
+
+  safe_copy = vmreader_safe_copy;
+}
+#endif
+
 /**
  * Copy a chunk of memory from a portion of the virtual memory of another
  * process.
@@ -48,6 +228,11 @@ static inline int copy_memory(proc_ref_t proc_ref, void *addr, ssize_t len, void
 {
     ssize_t result = -1;
 
+    // Early exit on zero page
+    if (reinterpret_cast<uintptr_t>(addr) < 4096) {
+        return result;
+    }
+
 #if defined PL_LINUX
     struct iovec local[1];
     struct iovec remote[1];
@@ -57,7 +242,7 @@ static inline int copy_memory(proc_ref_t proc_ref, void *addr, ssize_t len, void
     remote[0].iov_base = addr;
     remote[0].iov_len = len;
 
-    result = process_vm_readv(proc_ref, local, 1, remote, 1, 0);
+    result = safe_copy(proc_ref, local, 1, remote, 1, 0);
 
 #elif defined PL_DARWIN
     kern_return_t kr = mach_vm_read_overwrite(
@@ -72,7 +257,21 @@ static inline int copy_memory(proc_ref_t proc_ref, void *addr, ssize_t len, void
 
 #endif
 
+    static int count = 0;
+    static int mod = 1; // multiplied by 10 every time
+    if (len != result) {
+      count++;
+      if (count % mod == 0) {
+        // TODO we used to print an error here; can we do better?
+        mod *= 10;
+      }
+    }
+
     return len != result;
 }
 
 static pid_t pid = 0;
+
+void _set_pid(pid_t _pid) {
+    pid = _pid;
+}

--- a/echion/vm.h
+++ b/echion/vm.h
@@ -301,8 +301,3 @@ static inline int copy_memory(proc_ref_t proc_ref, void *addr, ssize_t len, void
 }
 
 static pid_t pid = 0;
-
-void _set_pid(pid_t _pid)
-{
-    pid = _pid;
-}

--- a/echion/vm.h
+++ b/echion/vm.h
@@ -106,7 +106,7 @@ class VmReader
         buffer = init(sz);
         if (!buffer)
         {
-            throw std::runtime_error("Failed to initialize VmReader");
+            throw std::runtime_error("Failed to initialize buffer with size " + std::to_string(sz));
         }
         instance = this;
     }

--- a/echion/vm.h
+++ b/echion/vm.h
@@ -172,7 +172,14 @@ public:
 
     ~VmReader()
     {
-        munmap(buffer, sz);
+        if (buffer)
+        {
+            munmap(buffer, sz);
+        }
+        if (fd != -1)
+        {
+            close(fd);
+        }
         instance = nullptr;
     }
 };

--- a/echion/vm.h
+++ b/echion/vm.h
@@ -49,128 +49,150 @@ bool failed_safe_copy = false;
 #if defined PL_LINUX
 ssize_t (*safe_copy)(pid_t, const struct iovec *, unsigned long, const struct iovec *, unsigned long, unsigned long) = process_vm_readv;
 
-class VmReader {
-  void *buffer;
-  size_t sz;
-  int fd{-1};
-  inline static VmReader *instance{nullptr};  // Prevents having to set this in implementation
+class VmReader
+{
+    void *buffer;
+    size_t sz;
+    int fd{-1};
+    inline static VmReader *instance{nullptr}; // Prevents having to set this in implementation
 
-  void* init(size_t new_sz) {
-    // Makes a temporary file and ftruncates it to the specified size
-    std::array<std::string, 3> tmp_dirs= {"/dev/shm", "/tmp", "/var/tmp"};
-    std::string tmp_suffix = "/echion-XXXXXX";
-    void* ret = nullptr;
+    void *init(size_t new_sz)
+    {
+        // Makes a temporary file and ftruncates it to the specified size
+        std::array<std::string, 3> tmp_dirs = {"/dev/shm", "/tmp", "/var/tmp"};
+        std::string tmp_suffix = "/echion-XXXXXX";
+        void *ret = nullptr;
 
-    for (auto &tmp_dir : tmp_dirs) {
-      // Reset the file descriptor, just in case
-      close(fd);
-      fd = -1;
+        for (auto &tmp_dir : tmp_dirs)
+        {
+            // Reset the file descriptor, just in case
+            close(fd);
+            fd = -1;
 
-      // Create the temporary file
-      std::string tmpfile = tmp_dir + tmp_suffix;
-      fd = mkstemp(tmpfile.data());
-      if (fd == -1)
-        continue;
+            // Create the temporary file
+            std::string tmpfile = tmp_dir + tmp_suffix;
+            fd = mkstemp(tmpfile.data());
+            if (fd == -1)
+                continue;
 
-      // Unlink might fail if delete is blocked on the VFS, but currently no action is taken
-      unlink(tmpfile.data());
+            // Unlink might fail if delete is blocked on the VFS, but currently no action is taken
+            unlink(tmpfile.data());
 
-      // Make sure we have enough size
-      if (ftruncate(fd, new_sz) == -1) {
-        continue;
-      }
+            // Make sure we have enough size
+            if (ftruncate(fd, new_sz) == -1)
+            {
+                continue;
+            }
 
-      // Map the file
-      ret = mmap(NULL, new_sz, PROT_READ | PROT_WRITE, MAP_PRIVATE, fd, 0);
-      if (ret == MAP_FAILED) {
-        ret = nullptr;
-        continue;
-      }
+            // Map the file
+            ret = mmap(NULL, new_sz, PROT_READ | PROT_WRITE, MAP_PRIVATE, fd, 0);
+            if (ret == MAP_FAILED)
+            {
+                ret = nullptr;
+                continue;
+            }
 
-      // Successful.  Break.
-      sz = new_sz;
-      break;
+            // Successful.  Break.
+            sz = new_sz;
+            break;
+        }
+
+        return ret;
     }
 
-    return ret;
-  }
-
-  VmReader(size_t _sz) : sz{_sz} {
-    buffer = init(sz);
-    if (!buffer) {
-      throw std::runtime_error("Failed to initialize VmReader");
+    VmReader(size_t _sz) : sz{_sz}
+    {
+        buffer = init(sz);
+        if (!buffer)
+        {
+            throw std::runtime_error("Failed to initialize VmReader");
+        }
+        instance = this;
     }
-    instance = this;
-  }
-
 
 public:
-  static VmReader *get_instance() {
-    if (instance == nullptr) {
-      try {
-        instance = new VmReader(1024 * 1024); // A megabyte?
-      } catch (std::exception &e) {
-        std::cerr << "Failed to initialize VmReader: " << e.what() << std::endl;
-      }
-    }
-    return instance;
-  }
-
-  ssize_t safe_copy(pid_t pid,
-                    const struct iovec *local_iov, unsigned long liovcnt,
-                    const struct iovec *remote_iov, unsigned long riovcnt, unsigned long flags) {
-    (void)pid;
-    (void)flags;
-    if (liovcnt != 1 || riovcnt != 1) {
-      // Unsupported
-      return 0;
-    }
-
-    // Check to see if we need to resize the buffer
-    if (remote_iov[0].iov_len > sz) {
-      if (ftruncate(fd, remote_iov[0].iov_len) == -1) {
-        return 0;
-      } else {
-        void *tmp = mremap(buffer, sz, remote_iov[0].iov_len, MREMAP_MAYMOVE);
-        if (tmp == MAP_FAILED) {
-          return 0;
+    static VmReader *get_instance()
+    {
+        if (instance == nullptr)
+        {
+            try
+            {
+                instance = new VmReader(1024 * 1024); // A megabyte?
+            }
+            catch (std::exception &e)
+            {
+                std::cerr << "Failed to initialize VmReader: " << e.what() << std::endl;
+            }
         }
-        buffer = tmp; // no need to munmap
-        sz = remote_iov[0].iov_len;
-      }
+        return instance;
     }
 
-    ssize_t ret = pwritev(fd, remote_iov, riovcnt, 0);
-    if (ret == -1) {
-      return ret;
+    ssize_t safe_copy(pid_t pid,
+                      const struct iovec *local_iov, unsigned long liovcnt,
+                      const struct iovec *remote_iov, unsigned long riovcnt, unsigned long flags)
+    {
+        (void)pid;
+        (void)flags;
+        if (liovcnt != 1 || riovcnt != 1)
+        {
+            // Unsupported
+            return 0;
+        }
+
+        // Check to see if we need to resize the buffer
+        if (remote_iov[0].iov_len > sz)
+        {
+            if (ftruncate(fd, remote_iov[0].iov_len) == -1)
+            {
+                return 0;
+            }
+            else
+            {
+                void *tmp = mremap(buffer, sz, remote_iov[0].iov_len, MREMAP_MAYMOVE);
+                if (tmp == MAP_FAILED)
+                {
+                    return 0;
+                }
+                buffer = tmp; // no need to munmap
+                sz = remote_iov[0].iov_len;
+            }
+        }
+
+        ssize_t ret = pwritev(fd, remote_iov, riovcnt, 0);
+        if (ret == -1)
+        {
+            return ret;
+        }
+
+        // Copy the data from the buffer to the remote process
+        memcpy(local_iov[0].iov_base, buffer, local_iov[0].iov_len);
+        return ret;
     }
 
-    // Copy the data from the buffer to the remote process
-    memcpy(local_iov[0].iov_base, buffer, local_iov[0].iov_len);
-    return ret;
-  }
-
-  ~VmReader() {
-    munmap(buffer, sz);
-    instance = nullptr;
-  }
+    ~VmReader()
+    {
+        munmap(buffer, sz);
+        instance = nullptr;
+    }
 };
 
 /**
-  * Initialize the safe copy operation on Linux
-  */
-bool read_process_vm_init() {
-  VmReader *_ = VmReader::get_instance();
-  return !!_;
+ * Initialize the safe copy operation on Linux
+ */
+bool read_process_vm_init()
+{
+    VmReader *_ = VmReader::get_instance();
+    return !!_;
 }
 
 ssize_t vmreader_safe_copy(pid_t pid,
-                       const struct iovec *local_iov, unsigned long liovcnt,
-                       const struct iovec *remote_iov, unsigned long riovcnt, unsigned long flags) {
-  auto reader = VmReader::get_instance();
-  if (!reader)
-    return 0;
-  return reader->safe_copy(pid, local_iov, liovcnt, remote_iov, riovcnt, flags);
+                           const struct iovec *local_iov, unsigned long liovcnt,
+                           const struct iovec *remote_iov, unsigned long riovcnt, unsigned long flags)
+{
+    auto reader = VmReader::get_instance();
+    if (!reader)
+        return 0;
+    return reader->safe_copy(pid, local_iov, liovcnt, remote_iov, riovcnt, flags);
 }
 
 /**
@@ -178,38 +200,43 @@ ssize_t vmreader_safe_copy(pid_t pid,
  *
  * This occurs at static init
  */
-__attribute__((constructor)) void init_safe_copy() {
-  char src[128];
-  char dst[128];
-  for (size_t i = 0; i < 128; i++) {
-    src[i] = 0x41;
-    dst[i] = ~0x42;
-  }
-
-  // Check to see that process_vm_readv works, unless it's overridden
-  const char force_override_str[] = "ECHION_ALT_VM_READ_FORCE";
-  const std::array<std::string, 6> truthy_values = {"1", "true", "yes", "on", "enable", "enabled"};
-  const char* force_override = std::getenv(force_override_str);
-  if (!force_override || std::find(truthy_values.begin(), truthy_values.end(), force_override) == truthy_values.end()) {
-    struct iovec iov_dst = {dst, sizeof(dst)};
-    struct iovec iov_src = {src, sizeof(src)};
-    ssize_t result = process_vm_readv(getpid(), &iov_dst, 1, &iov_src, 1, 0);
-
-    // If we succeed, then use process_vm_readv
-    if (result == sizeof(src)) {
-      safe_copy = process_vm_readv;
-      return;
+__attribute__((constructor)) void init_safe_copy()
+{
+    char src[128];
+    char dst[128];
+    for (size_t i = 0; i < 128; i++)
+    {
+        src[i] = 0x41;
+        dst[i] = ~0x42;
     }
-  }
 
-  // Else, we have to setup the writev method
-  if (!read_process_vm_init()) {
-    std::cerr << "Failed to initialize all safe copy interfaces" << std::endl;
-    failed_safe_copy = true;
-    return;
-  }
+    // Check to see that process_vm_readv works, unless it's overridden
+    const char force_override_str[] = "ECHION_ALT_VM_READ_FORCE";
+    const std::array<std::string, 6> truthy_values = {"1", "true", "yes", "on", "enable", "enabled"};
+    const char *force_override = std::getenv(force_override_str);
+    if (!force_override || std::find(truthy_values.begin(), truthy_values.end(), force_override) == truthy_values.end())
+    {
+        struct iovec iov_dst = {dst, sizeof(dst)};
+        struct iovec iov_src = {src, sizeof(src)};
+        ssize_t result = process_vm_readv(getpid(), &iov_dst, 1, &iov_src, 1, 0);
 
-  safe_copy = vmreader_safe_copy;
+        // If we succeed, then use process_vm_readv
+        if (result == sizeof(src))
+        {
+            safe_copy = process_vm_readv;
+            return;
+        }
+    }
+
+    // Else, we have to setup the writev method
+    if (!read_process_vm_init())
+    {
+        std::cerr << "Failed to initialize all safe copy interfaces" << std::endl;
+        failed_safe_copy = true;
+        return;
+    }
+
+    safe_copy = vmreader_safe_copy;
 }
 #endif
 
@@ -229,7 +256,8 @@ static inline int copy_memory(proc_ref_t proc_ref, void *addr, ssize_t len, void
     ssize_t result = -1;
 
     // Early exit on zero page
-    if (reinterpret_cast<uintptr_t>(addr) < 4096) {
+    if (reinterpret_cast<uintptr_t>(addr) < 4096)
+    {
         return result;
     }
 
@@ -259,12 +287,14 @@ static inline int copy_memory(proc_ref_t proc_ref, void *addr, ssize_t len, void
 
     static int count = 0;
     static int mod = 1; // multiplied by 10 every time
-    if (len != result) {
-      count++;
-      if (count % mod == 0) {
-        // TODO we used to print an error here; can we do better?
-        mod *= 10;
-      }
+    if (len != result)
+    {
+        count++;
+        if (count % mod == 0)
+        {
+            // TODO we used to print an error here; can we do better?
+            mod *= 10;
+        }
     }
 
     return len != result;
@@ -272,6 +302,7 @@ static inline int copy_memory(proc_ref_t proc_ref, void *addr, ssize_t len, void
 
 static pid_t pid = 0;
 
-void _set_pid(pid_t _pid) {
+void _set_pid(pid_t _pid)
+{
     pid = _pid;
 }

--- a/echion/vm.h
+++ b/echion/vm.h
@@ -239,7 +239,9 @@ __attribute__((constructor)) void init_safe_copy()
     // Else, we have to setup the writev method
     if (!read_process_vm_init())
     {
-        std::cerr << "Failed to initialize all safe copy interfaces" << std::endl;
+        // std::cerr might not have been fully initialized at this point, so use
+        // fprintf instead.
+        fprintf(stderr, "Failed to initialize all safe copy interfaces\n");
         failed_safe_copy = true;
         return;
     }

--- a/echion/vm.h
+++ b/echion/vm.h
@@ -285,18 +285,6 @@ static inline int copy_memory(proc_ref_t proc_ref, void *addr, ssize_t len, void
 
 #endif
 
-    static int count = 0;
-    static int mod = 1; // multiplied by 10 every time
-    if (len != result)
-    {
-        count++;
-        if (count % mod == 0)
-        {
-            // TODO we used to print an error here; can we do better?
-            mod *= 10;
-        }
-    }
-
     return len != result;
 }
 

--- a/echion/vm.h
+++ b/echion/vm.h
@@ -4,20 +4,21 @@
 
 #pragma once
 
-#include <iostream>
 #include <array>
-#include <string>
-#include <stdexcept>
 #include <cstdlib>
+#include <iostream>
+#include <stdexcept>
+#include <string>
 
 #if defined PL_LINUX
 #include <algorithm>
-#include <sys/uio.h>
-#include <sys/types.h>
-#include <unistd.h>
-#include <sys/stat.h>
 #include <fcntl.h>
+#include <memory>
 #include <sys/mman.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <sys/uio.h>
+#include <unistd.h>
 
 typedef pid_t proc_ref_t;
 


### PR DESCRIPTION
In many configurations, `process_vm_readv()` may be blocked at the syscall level (e.g., common Docker seccomp profile). This provides a simple failover using `writev()`. Note that this mechanism is not faster than `process_vm_readv()`.

This PR adds a few things.

- (semi-related) adds a quick failover in the common case of zero-page access
- Adds a check at static initialization on Linux for the availability of `process_vm_readv()`
- Implements a `VmReader` singleton class which holds the state for using alternative methods for reading VM. I could have put the `process_vm_readv()` switch here instead, but in the moment it felt right to factor this orthogonally to the current implementation
- Adds an environment variable, `ECHION_ALT_VM_READ_FORCE` for forcing the alternative safe reader (e.g., for benchmarking etc)

Description copied from https://github.com/P403n1x87/echion/pull/60
