### PR TITLE
fix: track main thread only if missing

### DIFF
--- a/echion/threads.h
+++ b/echion/threads.h
@@ -412,7 +412,10 @@ static void for_each_thread(PyInterpreterState *interp, std::function<void(PyThr
             {
                 // If the threading module was not imported in the target then
                 // we mistakenly take the hypno thread as the main thread. We
-                // assume that any missing thread is the actual main thread.
+                // assume that any missing thread is the actual main thread,
+                // provided we don't already have a thread with the name
+                // "MainThread". Note that this can also happen on shutdown, so
+                // we need to avoid doing anything in that case.
 #if PY_VERSION_HEX >= 0x030b0000
                 auto native_id = tstate.native_thread_id;
 #else
@@ -420,6 +423,18 @@ static void for_each_thread(PyInterpreterState *interp, std::function<void(PyThr
 #endif
                 try
                 {
+                    bool main_thread_tracked = false;
+                    for (auto &kv : thread_info_map)
+                    {
+                        if (kv.second->name == "MainThread")
+                        {
+                            main_thread_tracked = true;
+                            break;
+                        }
+                    }
+                    if (main_thread_tracked)
+                        continue;
+                    
                     thread_info_map.emplace(
                         tstate.thread_id,
                         std::make_unique<ThreadInfo>(tstate.thread_id, native_id, "MainThread"));


### PR DESCRIPTION
We make sure we don't accidentally mistaken a native thread for the main thread when we don't find its native ID within the thread tracking map. This can happen when attaching to a running process using hypno, in which case we are likely to be missing the main thread. There are cases where we can still get into the logic that supports this case, but for native threads that are not the main thread. When these threads die, they won't untrack themselves, causing us to look up their clock ID on Linux and crash.