### PR TITLE
fix: traverse `prev` and `next` tstates even if current one is skipped

### DIFF
--- a/echion/threads.h
+++ b/echion/threads.h
@@ -405,6 +405,12 @@ static void for_each_thread(PyInterpreterState *interp, std::function<void(PyThr
             // We failed to copy the thread so we skip it.
             continue;
 
+        // Enqueue the unseen threads that we can reach from this thread.
+        if (tstate.next != NULL && seen_threads.find(tstate.next) == seen_threads.end())
+            threads.insert(tstate.next);
+        if (tstate.prev != NULL && seen_threads.find(tstate.prev) == seen_threads.end())
+            threads.insert(tstate.prev);
+
         {
             const std::lock_guard<std::mutex> guard(thread_info_map_lock);
 
@@ -434,7 +440,7 @@ static void for_each_thread(PyInterpreterState *interp, std::function<void(PyThr
                     }
                     if (main_thread_tracked)
                         continue;
-                    
+
                     thread_info_map.emplace(
                         tstate.thread_id,
                         std::make_unique<ThreadInfo>(tstate.thread_id, native_id, "MainThread"));
@@ -451,11 +457,5 @@ static void for_each_thread(PyInterpreterState *interp, std::function<void(PyThr
             // Call back with the thread state and thread info.
             callback(&tstate, *thread_info_map.find(tstate.thread_id)->second);
         }
-
-        // Enqueue the unseen threads that we can reach from this thread.
-        if (tstate.next != NULL && seen_threads.find(tstate.next) == seen_threads.end())
-            threads.insert(tstate.next);
-        if (tstate.prev != NULL && seen_threads.find(tstate.prev) == seen_threads.end())
-            threads.insert(tstate.prev);
     }
 }


### PR DESCRIPTION
#83 introduced a check that a `PyThreadState` is skipped sampling if there's already `MainThread` in the `thread id` to `ThreadInfo` map. That unintentionally resulted in not traversing the `prev` and `next` `PyThreadState`s from the skipped one. This PR fixes that behavior. 