### PR TITLE
fix: CPython 3.13+ resolves frame addresses using stack_chunk

### DIFF
--- a/echion/frame.h
+++ b/echion/frame.h
@@ -132,9 +132,9 @@ public:
 #if PY_VERSION_HEX >= 0x030b0000
 
 #if PY_VERSION_HEX >= 0x030d0000
-        _PyInterpreterFrame *iframe = (_PyInterpreterFrame *)frame;
+        _PyInterpreterFrame* iframe = (_PyInterpreterFrame *)frame;
         const int lasti = _PyInterpreterFrame_LASTI(iframe);
-        PyCodeObject *code = (PyCodeObject *)iframe->f_executable;
+        PyCodeObject* code = (PyCodeObject *)iframe->f_executable;
 #else
         const _PyInterpreterFrame *iframe = (_PyInterpreterFrame *)frame;
         const int lasti = _PyInterpreterFrame_LASTI(iframe);
@@ -201,14 +201,14 @@ public:
     {
         if ((string_table.lookup(filename)).rfind("native@", 0) == 0)
             stream << "          \033[38;5;248;1m" << string_table.lookup(name)
-                   << "\033[0m \033[38;5;246m(" << string_table.lookup(filename)
-                   << "\033[0m:\033[38;5;246m" << location.line
-                   << ")\033[0m" << std::endl;
+            << "\033[0m \033[38;5;246m(" << string_table.lookup(filename)
+            << "\033[0m:\033[38;5;246m" << location.line
+            << ")\033[0m" << std::endl;
         else
             stream << "          \033[33;1m" << string_table.lookup(name)
-                   << "\033[0m (\033[36m" << string_table.lookup(filename)
-                   << "\033[0m:\033[32m" << location.line
-                   << "\033[0m)" << std::endl;
+            << "\033[0m (\033[36m" << string_table.lookup(filename)
+            << "\033[0m:\033[32m" << location.line
+            << "\033[0m)" << std::endl;
     }
 
 private:
@@ -348,7 +348,7 @@ private:
 #if PY_VERSION_HEX >= 0x030d0000
         _PyInterpreterFrame *iframe = (_PyInterpreterFrame *)frame;
         const int lasti = _PyInterpreterFrame_LASTI(iframe);
-        PyCodeObject *code = (PyCodeObject *)iframe->f_executable;
+        PyCodeObject* code = (PyCodeObject *)iframe->f_executable;
 #elif PY_VERSION_HEX >= 0x030b0000
         const _PyInterpreterFrame *iframe = (_PyInterpreterFrame *)frame;
         const int lasti = _PyInterpreterFrame_LASTI(iframe);

--- a/echion/frame.h
+++ b/echion/frame.h
@@ -528,29 +528,24 @@ Frame &Frame::read_with_stack_chunk(_PyInterpreterFrame *frame_addr, PyObject **
 
     for (; frame_addr; frame_addr = frame_addr->previous)
     {
-        std::cout << "Frame address: " << frame_addr << std::endl;
         auto resolved_address = stack_chunk->resolve(frame_addr);
 
         if (resolved_address == frame_addr)
         {
-            std::cout << "Need to copy from address" << std::endl;
             // We need to copy from the profiled thread
             if (copy_type(frame_addr, iframe))
             {
-                std::cout << "Copy failed for frame address " << (void *)frame_addr << std::endl;
                 throw Frame::Error();
             }
         }
         else
         {
-            std::cout << "Resolved to address in stack chunk" << std::endl;
             // We can safely read from resolved_address
             iframe = *(_PyInterpreterFrame *)resolved_address;
         }
         // TODO: Cache the executable address for faster reads.
         if (copy_type(iframe.f_executable, f_executable))
         {
-            std::cout << "Copy failed for f_executable " << (void *)iframe.f_executable << std::endl;
             throw Frame::Error();
         }
         if (f_executable.ob_type == &PyCode_Type)
@@ -568,10 +563,8 @@ Frame &Frame::read_with_stack_chunk(_PyInterpreterFrame *frame_addr, PyObject **
     auto resolved_addr = stack_chunk->resolve(frame_addr);
     if (resolved_addr == frame_addr)
     {
-        std::cout << "Resolved to address in stack chunk" << std::endl;
         if (copy_type(frame_addr, iframe))
         {
-            std::cout << "Copy failed for frame address " << (void *)frame_addr << std::endl;
             throw Frame::Error();
         }
     }

--- a/echion/frame.h
+++ b/echion/frame.h
@@ -415,7 +415,7 @@ Frame &Frame::read(PyObject *frame_addr, PyObject **prev_addr)
             }
             frame_addr = &iframe;
         }
-        if (copy_type(iframe.f_executable, f_executable))
+        if (copy_type(frame_addr->f_executable, f_executable))
         {
             throw Frame::Error();
         }

--- a/echion/frame.h
+++ b/echion/frame.h
@@ -476,14 +476,19 @@ Frame &Frame::read_with_stack_chunk(_PyInterpreterFrame *frame_addr, PyObject **
         // and we need to copy from the original address.
         if (resolved_addr != frame_addr)
         {
-            iframe = *(_PyInterpreterFrame *)resolved_addr;
+            frame_addr = reinterpret_cast<_PyInterpreterFrame *>(resolved_addr);
         }
-        else if (copy_type(frame_addr, iframe))
+        else
         {
-            throw Frame::Error();
+            if (copy_type(frame_addr, iframe))
+            {
+                throw Frame::Error();
+            }
+            frame_addr = &iframe;
         }
+
         // TODO: Cache the executable address for faster reads.
-        if (copy_type(iframe.f_executable, f_executable))
+        if (copy_type(frame_addr->f_executable, f_executable))
         {
             throw Frame::Error();
         }
@@ -502,32 +507,36 @@ Frame &Frame::read_with_stack_chunk(_PyInterpreterFrame *frame_addr, PyObject **
     auto resolved_addr = stack_chunk ? stack_chunk->resolve(frame_addr) : frame_addr;
     if (resolved_addr != frame_addr)
     {
-        iframe = *(_PyInterpreterFrame *)resolved_addr;
+        frame_addr = reinterpret_cast<_PyInterpreterFrame *>(resolved_addr);
     }
-    else if (copy_type(frame_addr, iframe))
+    else
     {
-        throw Frame::Error();
+        if (copy_type(frame_addr, iframe))
+        {
+            throw Frame::Error();
+        }
+        frame_addr = &iframe;
     }
 
     // We cannot use _PyInterpreterFrame_LASTI because _PyCode_CODE reads
     // from the code object.
 #if PY_VERSION_HEX >= 0x030d0000
-    const int lasti = ((int)(iframe.instr_ptr - 1 - (_Py_CODEUNIT *)((PyCodeObject *)iframe.f_executable))) - offsetof(PyCodeObject, co_code_adaptive) / sizeof(_Py_CODEUNIT);
-    auto &frame = Frame::get((PyCodeObject *)iframe.f_executable, lasti);
+    const int lasti = ((int)(frame_addr->instr_ptr - 1 - (_Py_CODEUNIT *)((PyCodeObject *)frame_addr->f_executable))) - offsetof(PyCodeObject, co_code_adaptive) / sizeof(_Py_CODEUNIT);
+    auto &frame = Frame::get((PyCodeObject *)frame_addr->f_executable, lasti);
 #else
-    const int lasti = ((int)(iframe.prev_instr - (_Py_CODEUNIT *)(iframe.f_code))) - offsetof(PyCodeObject, co_code_adaptive) / sizeof(_Py_CODEUNIT);
-    auto &frame = Frame::get(iframe.f_code, lasti);
+    const int lasti = ((int)(frame_addr->prev_instr - (_Py_CODEUNIT *)(frame_addr->f_code))) - offsetof(PyCodeObject, co_code_adaptive) / sizeof(_Py_CODEUNIT);
+    auto &frame = Frame::get(frame_addr->f_code, lasti);
 #endif // PY_VERSION_HEX >= 0x030d0000
     if (&frame != &INVALID_FRAME)
     {
 #if PY_VERSION_HEX >= 0x030c0000
-        frame.is_entry = (iframe.owner == FRAME_OWNED_BY_CSTACK); // Shim frame
+        frame.is_entry = (frame_addr->owner == FRAME_OWNED_BY_CSTACK); // Shim frame
 #else
         frame.is_entry = iframe.is_entry;
 #endif
     }
 
-    *prev_addr = &frame == &INVALID_FRAME ? NULL : (PyObject *)iframe.previous;
+    *prev_addr = &frame == &INVALID_FRAME ? NULL : (PyObject *)frame_addr->previous;
 
     return frame;
 }

--- a/echion/frame.h
+++ b/echion/frame.h
@@ -113,7 +113,6 @@ public:
 
     static Frame &read(PyObject *frame_addr, PyObject **prev_addr);
 #if PY_VERSION_HEX >= 0x030b0000
-    static Frame &read_local(_PyInterpreterFrame *frame_addr, PyObject **prev_addr);
     static Frame &read_with_stack_chunk(_PyInterpreterFrame *frame_addr, PyObject **prev_addr);
 #endif
 
@@ -455,66 +454,6 @@ Frame &Frame::read(PyObject *frame_addr, PyObject **prev_addr)
 }
 
 #if PY_VERSION_HEX >= 0x030b0000
-// ------------------------------------------------------------------------
-Frame &Frame::read_local(_PyInterpreterFrame *frame_addr, PyObject **prev_addr)
-{
-#if PY_VERSION_HEX >= 0x030d0000
-    // From Python versions 3.13, f_executable can have objects other than
-    // code objects for an internal frame. We need to skip some frames if
-    // its f_executable is not code as suggested here:
-    // https://github.com/python/cpython/issues/100987#issuecomment-1485556487
-    PyObject f_executable;
-
-    for (; frame_addr; frame_addr = frame_addr->previous)
-    {
-        // We need to check if the frame address is a valid value that's
-        // within the stack chunk. This is because some of the previous frames
-        // might have not been copied over using the stack chunk.
-        if (!stack_chunk->is_valid(frame_addr))
-        {
-            throw Frame::Error();
-        }
-        // TODO: Cache the executable address for faster reads.
-        if (copy_type(frame_addr->f_executable, f_executable))
-        {
-            throw Frame::Error();
-        }
-        if (f_executable.ob_type == &PyCode_Type)
-        {
-            break;
-        }
-    }
-
-    if (frame_addr == NULL)
-    {
-        throw Frame::Error();
-    }
-
-#endif // PY_VERSION_HEX >= 0x030d0000
-
-    // We cannot use _PyInterpreterFrame_LASTI because _PyCode_CODE reads
-    // from the code object.
-#if PY_VERSION_HEX >= 0x030d0000
-    const int lasti = ((int)(frame_addr->instr_ptr - 1 - (_Py_CODEUNIT *)((PyCodeObject *)frame_addr->f_executable))) - offsetof(PyCodeObject, co_code_adaptive) / sizeof(_Py_CODEUNIT);
-    auto &frame = Frame::get((PyCodeObject *)frame_addr->f_executable, lasti);
-#else
-    const int lasti = ((int)(frame_addr->prev_instr - (_Py_CODEUNIT *)(frame_addr->f_code))) - offsetof(PyCodeObject, co_code_adaptive) / sizeof(_Py_CODEUNIT);
-    auto &frame = Frame::get(frame_addr->f_code, lasti);
-#endif // PY_VERSION_HEX >= 0x030d0000
-    if (&frame != &INVALID_FRAME)
-    {
-#if PY_VERSION_HEX >= 0x030c0000
-        frame.is_entry = (frame_addr->owner == FRAME_OWNED_BY_CSTACK); // Shim frame
-#else
-        frame.is_entry = frame_addr->is_entry;
-#endif
-    }
-
-    *prev_addr = &frame == &INVALID_FRAME ? NULL : (PyObject *)frame_addr->previous;
-
-    return frame;
-}
-
 // ------------------------------------------------------------------------
 Frame &Frame::read_with_stack_chunk(_PyInterpreterFrame *frame_addr, PyObject **prev_addr)
 {

--- a/echion/frame.h
+++ b/echion/frame.h
@@ -134,7 +134,7 @@ public:
 #if PY_VERSION_HEX >= 0x030d0000
         _PyInterpreterFrame* iframe = (_PyInterpreterFrame *)frame;
         const int lasti = _PyInterpreterFrame_LASTI(iframe);
-        PyCodeObject* code = (PyCodeObject *)iframe->f_executable;
+        PyCodeObject* code = (PyCodeObject*)iframe->f_executable;
 #else
         const _PyInterpreterFrame *iframe = (_PyInterpreterFrame *)frame;
         const int lasti = _PyInterpreterFrame_LASTI(iframe);
@@ -348,7 +348,7 @@ private:
 #if PY_VERSION_HEX >= 0x030d0000
         _PyInterpreterFrame *iframe = (_PyInterpreterFrame *)frame;
         const int lasti = _PyInterpreterFrame_LASTI(iframe);
-        PyCodeObject* code = (PyCodeObject *)iframe->f_executable;
+        PyCodeObject* code = (PyCodeObject*)iframe->f_executable;
 #elif PY_VERSION_HEX >= 0x030b0000
         const _PyInterpreterFrame *iframe = (_PyInterpreterFrame *)frame;
         const int lasti = _PyInterpreterFrame_LASTI(iframe);
@@ -419,14 +419,12 @@ Frame &Frame::read(PyObject *frame_addr, PyObject **prev_addr)
         {
             throw Frame::Error();
         }
-        if (f_executable.ob_type == &PyCode_Type)
-        {
+        if (f_executable.ob_type == &PyCode_Type) {
             break;
         }
     }
 
-    if (frame_addr == NULL)
-    {
+    if (frame_addr == NULL) {
         throw Frame::Error();
     }
 #else

--- a/echion/frame.h
+++ b/echion/frame.h
@@ -29,7 +29,9 @@
 
 #include <echion/cache.h>
 #include <echion/mojo.h>
+#if PY_VERSION_HEX >= 0x030b0000
 #include <echion/stack_chunk.h>
+#endif // PY_VERSION_HEX >= 0x030b0000
 #include <echion/strings.h>
 #include <echion/vm.h>
 

--- a/echion/frame.h
+++ b/echion/frame.h
@@ -467,20 +467,29 @@ Frame &Frame::read_with_stack_chunk(_PyInterpreterFrame *frame_addr, PyObject **
 
     for (; frame_addr; frame_addr = frame_addr->previous)
     {
-        auto resolved_address = stack_chunk->resolve(frame_addr);
-
-        if (resolved_address == frame_addr)
+        if (stack_chunk != nullptr)
         {
-            // We need to copy from the profiled thread
-            if (copy_type(frame_addr, iframe))
+            auto resolved_address = stack_chunk->resolve(frame_addr);
+            if (resolved_address == frame_addr)
             {
-                throw Frame::Error();
+                // We need to copy from the profiled thread
+                if (copy_type(frame_addr, iframe))
+                {
+                    throw Frame::Error();
+                }
+            }
+            else
+            {
+                // We can safely read from resolved_address
+                iframe = *(_PyInterpreterFrame *)resolved_address;
             }
         }
         else
         {
-            // We can safely read from resolved_address
-            iframe = *(_PyInterpreterFrame *)resolved_address;
+            if (copy_type(frame_addr, iframe))
+            {
+                throw Frame::Error();
+            }
         }
         // TODO: Cache the executable address for faster reads.
         if (copy_type(iframe.f_executable, f_executable))
@@ -499,17 +508,27 @@ Frame &Frame::read_with_stack_chunk(_PyInterpreterFrame *frame_addr, PyObject **
     }
 #endif // PY_VERSION_HEX >= 0x030d0000
 
-    auto resolved_addr = stack_chunk->resolve(frame_addr);
-    if (resolved_addr == frame_addr)
+    if (stack_chunk != nullptr)
+    {
+        auto resolved_addr = stack_chunk->resolve(frame_addr);
+        if (resolved_addr == frame_addr)
+        {
+            if (copy_type(frame_addr, iframe))
+            {
+                throw Frame::Error();
+            }
+        }
+        else
+        {
+            iframe = *(_PyInterpreterFrame *)resolved_addr;
+        }
+    }
+    else
     {
         if (copy_type(frame_addr, iframe))
         {
             throw Frame::Error();
         }
-    }
-    else
-    {
-        iframe = *(_PyInterpreterFrame *)resolved_addr;
     }
 
     // We cannot use _PyInterpreterFrame_LASTI because _PyCode_CODE reads

--- a/echion/stack_chunk.h
+++ b/echion/stack_chunk.h
@@ -10,7 +10,6 @@
 #include <exception>
 #include <memory>
 
-#if PY_VERSION_HEX >= 0x030b0000
 // ----------------------------------------------------------------------------
 
 class StackChunkError : public std::exception
@@ -85,4 +84,3 @@ void *StackChunk::resolve(void *address)
 // ----------------------------------------------------------------------------
 
 static std::unique_ptr<StackChunk> stack_chunk = nullptr;
-#endif

--- a/echion/stack_chunk.h
+++ b/echion/stack_chunk.h
@@ -1,0 +1,97 @@
+// This file is part of "echion" which is released under MIT.
+//
+// Copyright (c) 2023 Gabriele N. Tornetta <phoenix1987@gmail.com>.
+
+#pragma once
+
+#define PY_SSIZE_T_CLEAN
+#include <Python.h>
+
+#include <exception>
+#include <memory>
+
+#if PY_VERSION_HEX >= 0x030b0000
+// ----------------------------------------------------------------------------
+
+class StackChunkError : public std::exception
+{
+public:
+  const char *what() const noexcept override
+  {
+    return "Cannot create stack chunk object";
+  }
+};
+
+// ----------------------------------------------------------------------------
+class StackChunk
+{
+public:
+  StackChunk(PyThreadState *tstate) : StackChunk((_PyStackChunk *)tstate->datastack_chunk) {}
+
+  void *resolve(void *frame_addr);
+  bool is_valid(void *frame_addr);
+
+private:
+  void *origin = NULL;
+  std::unique_ptr<char[]> data = nullptr;
+  std::unique_ptr<StackChunk> previous = nullptr;
+
+  StackChunk(_PyStackChunk *chunk_addr);
+};
+
+// ----------------------------------------------------------------------------
+StackChunk::StackChunk(_PyStackChunk *chunk_addr)
+{
+  _PyStackChunk chunk;
+
+  // Copy the chunk header first
+  if (copy_type(chunk_addr, chunk))
+    throw StackChunkError();
+
+  origin = chunk_addr;
+  data = std::make_unique<char[]>(chunk.size);
+
+  // Copy the full chunk
+  if (copy_generic(chunk_addr, data.get(), chunk.size))
+    throw StackChunkError();
+
+  if (chunk.previous != NULL)
+  {
+    try
+    {
+      previous = std::unique_ptr<StackChunk>{new StackChunk((_PyStackChunk *)chunk.previous)};
+    }
+    catch (StackChunkError &e)
+    {
+      previous = nullptr;
+    }
+  }
+}
+
+// ----------------------------------------------------------------------------
+void *StackChunk::resolve(void *address)
+{
+  _PyStackChunk *chunk = (_PyStackChunk *)data.get();
+
+  // Check if this chunk contains the address
+  if (address >= origin && address < (char *)origin + chunk->size)
+    return (char *)chunk + ((char *)address - (char *)origin);
+
+  if (previous)
+    return previous->resolve(address);
+
+  return address;
+}
+
+// ----------------------------------------------------------------------------
+bool StackChunk::is_valid(void *address)
+{
+  _PyStackChunk *chunk = (_PyStackChunk *)data.get();
+
+  return address >= (void *)chunk && address < (void *)((char *)chunk + chunk->size);
+}
+
+// ----------------------------------------------------------------------------
+
+static std::unique_ptr<StackChunk> stack_chunk = nullptr;
+#endif

--- a/echion/stack_chunk.h
+++ b/echion/stack_chunk.h
@@ -29,7 +29,6 @@ public:
   StackChunk(PyThreadState *tstate) : StackChunk((_PyStackChunk *)tstate->datastack_chunk) {}
 
   void *resolve(void *frame_addr);
-  bool is_valid(void *frame_addr);
 
 private:
   void *origin = NULL;
@@ -81,20 +80,6 @@ void *StackChunk::resolve(void *address)
     return previous->resolve(address);
 
   return address;
-}
-
-// ----------------------------------------------------------------------------
-bool StackChunk::is_valid(void *address)
-{
-  _PyStackChunk *chunk = (_PyStackChunk *)data.get();
-
-  if (address >= (void *)chunk && address < (void *)((char *)chunk + chunk->size))
-  {
-    return true;
-  }
-  if (previous)
-    return previous->is_valid(address);
-  return false;
 }
 
 // ----------------------------------------------------------------------------

--- a/echion/stack_chunk.h
+++ b/echion/stack_chunk.h
@@ -88,7 +88,13 @@ bool StackChunk::is_valid(void *address)
 {
   _PyStackChunk *chunk = (_PyStackChunk *)data.get();
 
-  return address >= (void *)chunk && address < (void *)((char *)chunk + chunk->size);
+  if (address >= (void *)chunk && address < (void *)((char *)chunk + chunk->size))
+  {
+    return true;
+  }
+  if (previous)
+    return previous->is_valid(address);
+  return false;
 }
 
 // ----------------------------------------------------------------------------

--- a/echion/stacks.h
+++ b/echion/stacks.h
@@ -148,7 +148,7 @@ unwind_frame_unsafe(PyObject *frame, FrameStack &stack)
 #if PY_VERSION_HEX >= 0x030d0000
         // See the comment in unwind_frame()
         while (current_frame != NULL) {
-            if (((_PyInterpreterFrame *)current_frame)->f_executable->ob_type == &PyCode_Type) {
+            if (((_PyInterpreterFrame*)current_frame)->f_executable->ob_type == &PyCode_Type) {
                 break;
             }
             current_frame = (PyObject *)((_PyInterpreterFrame *)current_frame)->previous;

--- a/echion/stacks.h
+++ b/echion/stacks.h
@@ -117,10 +117,8 @@ unwind_frame(PyObject *frame_addr, FrameStack &stack)
         try
         {
 #if PY_VERSION_HEX >= 0x030b0000
-            auto resolved_address = stack_chunk ? stack_chunk->resolve(current_frame_addr) : current_frame_addr;
-            Frame &frame = resolved_address != current_frame_addr
-                               ? Frame::read_local((_PyInterpreterFrame *)resolved_address, &current_frame_addr)
-                               : Frame::read((PyObject *)current_frame_addr, &current_frame_addr);
+            Frame &frame = Frame::read_with_stack_chunk(
+                (_PyInterpreterFrame *)current_frame_addr, &current_frame_addr);
 #else
             Frame &frame = Frame::read(current_frame_addr, &current_frame_addr);
 #endif

--- a/echion/stacks.h
+++ b/echion/stacks.h
@@ -118,8 +118,7 @@ unwind_frame(PyObject *frame_addr, FrameStack &stack)
                 reinterpret_cast<_PyInterpreterFrame *>(current_frame_addr),
                 reinterpret_cast<_PyInterpreterFrame **>(&current_frame_addr));
 #else
-            Frame &frame = Frame::read(
-                current_frame_addr, &current_frame_addr);
+            Frame &frame = Frame::read(current_frame_addr, &current_frame_addr);
 #endif
             stack.push_back(frame);
         }
@@ -184,14 +183,13 @@ unwind_python_stack(PyThreadState *tstate, FrameStack &stack)
     try {
         stack_chunk = std::make_unique<StackChunk>(tstate);
     }
-    catch (StackChunkError &e)
-    {
+    catch (StackChunkError &e) {
         stack_chunk = nullptr;
     }
 #endif
 
 #if PY_VERSION_HEX >= 0x030d0000
-    PyObject* frame_addr = (PyObject *)tstate->current_frame;
+    PyObject* frame_addr = (PyObject*)tstate->current_frame;
 #elif PY_VERSION_HEX >= 0x030b0000
     _PyCFrame cframe;
     _PyCFrame *cframe_addr = tstate->cframe;

--- a/echion/stacks.h
+++ b/echion/stacks.h
@@ -20,7 +20,6 @@
 #include <echion/config.h>
 #include <echion/frame.h>
 #include <echion/mojo.h>
-#include <echion/stack_chunk.h>
 
 // ----------------------------------------------------------------------------
 
@@ -115,10 +114,12 @@ unwind_frame(PyObject *frame_addr, FrameStack &stack)
         try
         {
 #if PY_VERSION_HEX >= 0x030b0000
-            Frame &frame = Frame::read_with_stack_chunk(
-                (_PyInterpreterFrame *)current_frame_addr, &current_frame_addr);
+            Frame &frame = Frame::read(
+                reinterpret_cast<_PyInterpreterFrame *>(current_frame_addr),
+                reinterpret_cast<_PyInterpreterFrame **>(&current_frame_addr));
 #else
-            Frame &frame = Frame::read(current_frame_addr, &current_frame_addr);
+            Frame &frame = Frame::read(
+                current_frame_addr, &current_frame_addr);
 #endif
             stack.push_back(frame);
         }

--- a/echion/stacks.h
+++ b/echion/stacks.h
@@ -148,17 +148,14 @@ unwind_frame_unsafe(PyObject *frame, FrameStack &stack)
 
 #if PY_VERSION_HEX >= 0x030d0000
         // See the comment in unwind_frame()
-        while (current_frame != NULL)
-        {
-            if (((_PyInterpreterFrame *)current_frame)->f_executable->ob_type == &PyCode_Type)
-            {
+        while (current_frame != NULL) {
+            if (((_PyInterpreterFrame *)current_frame)->f_executable->ob_type == &PyCode_Type) {
                 break;
             }
             current_frame = (PyObject *)((_PyInterpreterFrame *)current_frame)->previous;
         }
 
-        if (current_frame == NULL)
-        {
+        if (current_frame == NULL) {
             break;
         }
 #endif // PY_VERSION_HEX >= 0x030d0000
@@ -184,8 +181,7 @@ unwind_python_stack(PyThreadState *tstate, FrameStack &stack)
 {
     stack.clear();
 #if PY_VERSION_HEX >= 0x030b0000
-    try
-    {
+    try {
         stack_chunk = std::make_unique<StackChunk>(tstate);
     }
     catch (StackChunkError &e)
@@ -195,7 +191,7 @@ unwind_python_stack(PyThreadState *tstate, FrameStack &stack)
 #endif
 
 #if PY_VERSION_HEX >= 0x030d0000
-    PyObject *frame_addr = (PyObject *)tstate->current_frame;
+    PyObject* frame_addr = (PyObject *)tstate->current_frame;
 #elif PY_VERSION_HEX >= 0x030b0000
     _PyCFrame cframe;
     _PyCFrame *cframe_addr = tstate->cframe;
@@ -216,18 +212,16 @@ unwind_python_stack_unsafe(PyThreadState *tstate, FrameStack &stack)
 {
     stack.clear();
 #if PY_VERSION_HEX >= 0x030b0000
-    try
-    {
+    try {
         stack_chunk = std::make_unique<StackChunk>(tstate);
     }
-    catch (StackChunkError &e)
-    {
+    catch (StackChunkError &e) {
         stack_chunk = nullptr;
     }
 #endif
 
 #if PY_VERSION_HEX >= 0x030d0000
-    PyObject *frame_addr = (PyObject *)tstate->current_frame;
+    PyObject* frame_addr = (PyObject*)tstate->current_frame;
 #elif PY_VERSION_HEX >= 0x030b0000
     PyObject *frame_addr = (PyObject *)tstate->cframe->current_frame;
 #else // Python < 3.11

--- a/echion/stacks.h
+++ b/echion/stacks.h
@@ -22,8 +22,6 @@
 #include <echion/mojo.h>
 #include <echion/stack_chunk.h>
 
-#define MAX_FRAMES 2048
-
 // ----------------------------------------------------------------------------
 
 class FrameStack : public std::deque<Frame::Ref>


### PR DESCRIPTION
#74 enabled us to read from local `stack_chunk` when available. And some of CPython 3.13+ tests were segfaulting since then, see #85 for examples. This PR fixes them. 

Since CPython 3.13, objects other than code objects can exist as "executable" of an internal frame, see 	https://github.com/python/cpython/pull/105727. This required us to iterate over frame objects checking the type, and we need to make sure those frame addresses are resolved using `stack_chunk` or copied properly. 