### PR TITLE
fix: frame address resolution on CPython 3.13

### DIFF
--- a/echion/frame.h
+++ b/echion/frame.h
@@ -475,11 +475,12 @@ Frame &Frame::read_local(_PyInterpreterFrame *frame_addr, PyObject **prev_addr)
         // Get the previous frame
         auto prev_frame_addr = frame_addr->previous;
         if (prev_frame_addr == NULL) {
+            frame_addr = NULL;
             break;
         }
 
         // There is a previous frame, so we need to resolve it.
-        frame_addr = stack_chunk->resolve(prev_frame_addr);
+        frame_addr = (_PyInterpreterFrame*)(stack_chunk ? stack_chunk->resolve(prev_frame_addr) : prev_frame_addr);
         if (frame_addr == prev_frame_addr) {
             // The frame is not within the stack chunk so we need to copy it
             _PyInterpreterFrame iframe;

--- a/echion/stack_chunk.h
+++ b/echion/stack_chunk.h
@@ -1,0 +1,80 @@
+// This file is part of "echion" which is released under MIT.
+//
+// Copyright (c) 2023 Gabriele N. Tornetta <phoenix1987@gmail.com>.
+
+#pragma once
+
+#define PY_SSIZE_T_CLEAN
+#include <Python.h>
+
+// ----------------------------------------------------------------------------
+
+class StackChunkError : public std::exception
+{
+public:
+    const char *what() const noexcept override
+    {
+        return "Cannot create stack chunk object";
+    }
+};
+
+// ----------------------------------------------------------------------------
+class StackChunk
+{
+public:
+    StackChunk(PyThreadState *tstate) : StackChunk((_PyStackChunk *)tstate->datastack_chunk) {}
+
+    void* resolve(void *frame_addr);
+
+private:
+    void* origin = NULL;
+    std::unique_ptr<char[]> data = nullptr;
+    std::unique_ptr<StackChunk> previous = nullptr;
+
+    StackChunk(_PyStackChunk *chunk_addr);
+};
+
+// ----------------------------------------------------------------------------
+StackChunk::StackChunk(_PyStackChunk *chunk_addr)
+{
+    _PyStackChunk chunk;
+
+    // Copy the chunk header first
+    if (copy_type(chunk_addr, chunk))
+        throw StackChunkError();
+
+    origin = chunk_addr;
+    data = std::make_unique<char[]>(chunk.size);
+
+    // Copy the full chunk
+    if (copy_generic(chunk_addr, data.get(), chunk.size))
+        throw StackChunkError();
+
+    if (chunk.previous != NULL) {
+        try {
+            previous = std::unique_ptr<StackChunk>{ new StackChunk((_PyStackChunk*)chunk.previous) };
+        }
+        catch (StackChunkError &e) {
+            previous = nullptr;
+        }
+    }
+}
+
+// ----------------------------------------------------------------------------
+void* StackChunk::resolve(void *address)
+{
+    _PyStackChunk *chunk = (_PyStackChunk *)data.get();
+
+    // Check if this chunk contains the address
+    if (address >= origin && address < (char *)origin + chunk->size)
+        return (char *)chunk + ((char *)address - (char *)origin);
+
+    if (previous)
+        return previous->resolve(address);
+
+    return address;
+}
+
+// ----------------------------------------------------------------------------
+
+static std::unique_ptr<StackChunk> stack_chunk = nullptr;

--- a/echion/stacks.h
+++ b/echion/stacks.h
@@ -22,77 +22,7 @@
 #include <echion/mojo.h>
 
 #if PY_VERSION_HEX >= 0x030b0000
-// ----------------------------------------------------------------------------
-
-class StackChunkError : public std::exception
-{
-public:
-    const char *what() const noexcept override
-    {
-        return "Cannot create stack chunk object";
-    }
-};
-
-// ----------------------------------------------------------------------------
-class StackChunk
-{
-public:
-    StackChunk(PyThreadState *tstate) : StackChunk((_PyStackChunk *)tstate->datastack_chunk) {}
-
-    void* resolve(void *frame_addr);
-
-private:
-    void* origin = NULL;
-    std::unique_ptr<char[]> data = nullptr;
-    std::unique_ptr<StackChunk> previous = nullptr;
-
-    StackChunk(_PyStackChunk *chunk_addr);
-};
-
-// ----------------------------------------------------------------------------
-StackChunk::StackChunk(_PyStackChunk *chunk_addr)
-{
-    _PyStackChunk chunk;
-
-    // Copy the chunk header first
-    if (copy_type(chunk_addr, chunk))
-        throw StackChunkError();
-
-    origin = chunk_addr;
-    data = std::make_unique<char[]>(chunk.size);
-
-    // Copy the full chunk
-    if (copy_generic(chunk_addr, data.get(), chunk.size))
-        throw StackChunkError();
-
-    if (chunk.previous != NULL) {
-        try {
-            previous = std::unique_ptr<StackChunk>{ new StackChunk((_PyStackChunk*)chunk.previous) };
-        }
-        catch (StackChunkError &e) {
-            previous = nullptr;
-        }
-    }
-}
-
-// ----------------------------------------------------------------------------
-void* StackChunk::resolve(void *address)
-{
-    _PyStackChunk *chunk = (_PyStackChunk *)data.get();
-
-    // Check if this chunk contains the address
-    if (address >= origin && address < (char *)origin + chunk->size)
-        return (char *)chunk + ((char *)address - (char *)origin);
-
-    if (previous)
-        return previous->resolve(address);
-
-    return address;
-}
-
-// ----------------------------------------------------------------------------
-
-static std::unique_ptr<StackChunk> stack_chunk = nullptr;
+#include <echion/stack_chunk.h>
 #endif
 
 // ----------------------------------------------------------------------------


### PR DESCRIPTION
We fix a bug in the frame address resolution logic when reading a frame from a local copy of a stack chunk.