### PR TITLE
fix: copy code object only when cache miss

### DIFF
--- a/echion/frame.h
+++ b/echion/frame.h
@@ -502,10 +502,6 @@ Frame &Frame::read_local(_PyInterpreterFrame *frame_addr, PyObject **prev_addr)
 // ----------------------------------------------------------------------------
 Frame &Frame::get(PyCodeObject *code_addr, int lasti)
 {
-    PyCodeObject code;
-    if (copy_type(code_addr, code))
-        return INVALID_FRAME;
-
     auto frame_key = Frame::key(code_addr, lasti);
 
     try
@@ -516,6 +512,10 @@ Frame &Frame::get(PyCodeObject *code_addr, int lasti)
     {
         try
         {
+            PyCodeObject code;
+            if (copy_type(code_addr, code))
+              return INVALID_FRAME;
+
             auto new_frame = std::make_unique<Frame>(&code, lasti);
             new_frame->cache_key = frame_key;
             auto &f = *new_frame;


### PR DESCRIPTION
<img width="676" alt="Screenshot 2025-03-03 at 8 01 13 PM" src="https://github.com/user-attachments/assets/49fae9f0-b17f-47a6-bbec-bb06f3cff099" />

Noticed while running dd-trace-py with ddprof, using 1.95s out of 7.32s (26%) of stack_v2 cpu time

This change drastically reduces the amount of time we spend on `process_vm_readv`

<img width="1344" alt="Screenshot 2025-03-03 at 9 17 36 PM" src="https://github.com/user-attachments/assets/be67e2e4-6b02-4bae-bba5-04638800480a" />
