### PR TITLE
refactor: split frame.h into frame.h and frame.cc

### DIFF
--- a/echion/cache.h
+++ b/echion/cache.h
@@ -6,6 +6,7 @@
 
 #include <exception>
 #include <list>
+#include <memory>
 #include <unordered_map>
 
 #define CACHE_MAX_ENTRIES 2048

--- a/echion/config.h
+++ b/echion/config.h
@@ -12,29 +12,29 @@
 #include <signal.h>
 
 // Sampling interval
-static unsigned int interval = 1000;
+inline unsigned int interval = 1000;
 
 // CPU Time mode
-static int cpu = 0;
+inline int cpu = 0;
 
 // For cpu time mode, Echion only unwinds threads that're running by default.
 // Set this to false to unwind all threads.
 inline bool ignore_non_running_threads = true;
 
 // Memory events
-static int memory = 0;
+inline int memory = 0;
 
 // Native stack sampling
-static int native = 0;
+inline int native = 0;
 
 // Where mode
-static int where = 0;
+inline int where = 0;
 
 // Maximum number of frames to unwind
-static unsigned int max_frames = 2048;
+inline unsigned int max_frames = 2048;
 
 // Pipe name (where mode IPC)
-static std::string pipe_name;
+inline std::string pipe_name;
 
 // ----------------------------------------------------------------------------
 static PyObject *

--- a/echion/frame.cc
+++ b/echion/frame.cc
@@ -1,0 +1,483 @@
+#include <echion/frame.h>
+
+// ----------------------------------------------------------------------------
+#if PY_VERSION_HEX >= 0x030b0000
+static inline int
+_read_varint(unsigned char *table, ssize_t size, ssize_t *i)
+{
+    ssize_t guard = size - 1;
+    if (*i >= guard)
+        return 0;
+
+    int val = table[++*i] & 63;
+    int shift = 0;
+    while (table[*i] & 64 && *i < guard)
+    {
+        shift += 6;
+        val |= (table[++*i] & 63) << shift;
+    }
+    return val;
+}
+
+// ----------------------------------------------------------------------------
+static inline int
+_read_signed_varint(unsigned char *table, ssize_t size, ssize_t *i)
+{
+    int val = _read_varint(table, size, i);
+    return (val & 1) ? -(val >> 1) : (val >> 1);
+}
+#endif
+
+// ----------------------------------------------------------------------------
+void init_frame_cache(size_t capacity)
+{
+    frame_cache = new LRUCache<uintptr_t, Frame>(capacity);
+}
+
+// ----------------------------------------------------------------------------
+void reset_frame_cache()
+{
+    delete frame_cache;
+    frame_cache = nullptr;
+}
+
+// ------------------------------------------------------------------------
+Frame::Frame(PyObject *frame)
+{
+#if PY_VERSION_HEX >= 0x030b0000
+
+#if PY_VERSION_HEX >= 0x030d0000
+    _PyInterpreterFrame* iframe = (_PyInterpreterFrame *)frame;
+    const int lasti = _PyInterpreterFrame_LASTI(iframe);
+    PyCodeObject* code = (PyCodeObject*)iframe->f_executable;
+#else
+    const _PyInterpreterFrame *iframe = (_PyInterpreterFrame *)frame;
+    const int lasti = _PyInterpreterFrame_LASTI(iframe);
+    PyCodeObject *code = iframe->f_code;
+#endif // PY_VERSION_HEX >= 0x030d0000
+    PyCode_Addr2Location(code, lasti << 1, &location.line, &location.column, &location.line_end, &location.column_end);
+    location.column++;
+    location.column_end++;
+    name = string_table.key_unsafe(code->co_qualname);
+#if PY_VERSION_HEX >= 0x030c0000
+    is_entry = (iframe->owner == FRAME_OWNED_BY_CSTACK); // Shim frame
+#else
+    is_entry = iframe->is_entry;
+#endif
+
+#else
+    PyFrameObject *py_frame = (PyFrameObject *)frame;
+    PyCodeObject *code = py_frame->f_code;
+
+    location.line = PyFrame_GetLineNumber(py_frame);
+    name = string_table.key_unsafe(code->co_name);
+#endif
+    filename = string_table.key_unsafe(code->co_filename);
+}
+
+// ------------------------------------------------------------------------
+Frame::Frame(PyCodeObject *code, int lasti)
+{
+    try
+    {
+        filename = string_table.key(code->co_filename);
+#if PY_VERSION_HEX >= 0x030b0000
+        name = string_table.key(code->co_qualname);
+#else
+        name = string_table.key(code->co_name);
+#endif
+    }
+    catch (StringTable::Error &)
+    {
+        throw Error();
+    }
+
+    infer_location(code, lasti);
+}
+
+// ------------------------------------------------------------------------
+#ifndef UNWIND_NATIVE_DISABLE
+Frame::Frame(unw_cursor_t &cursor, unw_word_t pc)
+{
+    try
+    {
+        filename = string_table.key(pc);
+        name = string_table.key(cursor);
+    }
+    catch (StringTable::Error &)
+    {
+        throw Error();
+    }
+}
+#endif // UNWIND_NATIVE_DISABLE
+
+// ------------------------------------------------------------------------
+void Frame::render_where(std::ostream &stream)
+{
+    if ((string_table.lookup(filename)).rfind("native@", 0) == 0)
+        stream << "          \033[38;5;248;1m" << string_table.lookup(name)
+        << "\033[0m \033[38;5;246m(" << string_table.lookup(filename)
+        << "\033[0m:\033[38;5;246m" << location.line
+        << ")\033[0m" << std::endl;
+    else
+        stream << "          \033[33;1m" << string_table.lookup(name)
+        << "\033[0m (\033[36m" << string_table.lookup(filename)
+        << "\033[0m:\033[32m" << location.line
+        << "\033[0m)" << std::endl;
+}
+
+// ----------------------------------------------------------------------------
+void Frame::infer_location(PyCodeObject *code, int lasti)
+{
+    unsigned int lineno = code->co_firstlineno;
+    Py_ssize_t len = 0;
+
+#if PY_VERSION_HEX >= 0x030b0000
+    auto table = pybytes_to_bytes_and_size(code->co_linetable, &len);
+    if (table == nullptr)
+        throw LocationError();
+
+    auto table_data = table.get();
+
+    for (Py_ssize_t i = 0, bc = 0; i < len; i++)
+    {
+        bc += (table[i] & 7) + 1;
+        int code = (table[i] >> 3) & 15;
+        unsigned char next_byte = 0;
+        switch (code)
+        {
+        case 15:
+            break;
+
+        case 14: // Long form
+            lineno += _read_signed_varint(table_data, len, &i);
+
+            this->location.line = lineno;
+            this->location.line_end = lineno + _read_varint(table_data, len, &i);
+            this->location.column = _read_varint(table_data, len, &i);
+            this->location.column_end = _read_varint(table_data, len, &i);
+
+            break;
+
+        case 13: // No column data
+            lineno += _read_signed_varint(table_data, len, &i);
+
+            this->location.line = lineno;
+            this->location.line_end = lineno;
+            this->location.column = this->location.column_end = 0;
+
+            break;
+
+        case 12: // New lineno
+        case 11:
+        case 10:
+            if (i >= len - 2)
+                throw LocationError();
+
+            lineno += code - 10;
+
+            this->location.line = lineno;
+            this->location.line_end = lineno;
+            this->location.column = 1 + table[++i];
+            this->location.column_end = 1 + table[++i];
+
+            break;
+
+        default:
+            if (i >= len - 1)
+                throw LocationError();
+
+            next_byte = table[++i];
+
+            this->location.line = lineno;
+            this->location.line_end = lineno;
+            this->location.column = 1 + (code << 3) + ((next_byte >> 4) & 7);
+            this->location.column_end = this->location.column + (next_byte & 15);
+        }
+
+        if (bc > lasti)
+            break;
+    }
+
+#elif PY_VERSION_HEX >= 0x030a0000
+    auto table = pybytes_to_bytes_and_size(code->co_linetable, &len);
+    if (table == nullptr)
+        throw LocationError();
+
+    lasti <<= 1;
+    for (int i = 0, bc = 0; i < len; i++)
+    {
+        int sdelta = table[i++];
+        if (sdelta == 0xff)
+            break;
+
+        bc += sdelta;
+
+        int ldelta = table[i];
+        if (ldelta == 0x80)
+            ldelta = 0;
+        else if (ldelta > 0x80)
+            lineno -= 0x100;
+
+        lineno += ldelta;
+        if (bc > lasti)
+            break;
+    }
+
+#else
+    auto table = pybytes_to_bytes_and_size(code->co_lnotab, &len);
+    if (table == nullptr)
+        throw LocationError();
+
+    for (int i = 0, bc = 0; i < len; i++)
+    {
+        bc += table[i++];
+        if (bc > lasti)
+            break;
+
+        if (table[i] >= 0x80)
+            lineno -= 0x100;
+
+        lineno += table[i];
+    }
+
+#endif
+
+    this->location.line = lineno;
+    this->location.line_end = lineno;
+    this->location.column = 0;
+    this->location.column_end = 0;
+}
+
+// ------------------------------------------------------------------------
+Frame::Key Frame::key(PyCodeObject *code, int lasti)
+{
+    return (((uintptr_t)(((uintptr_t)code) & MOJO_INT32) << 16) | lasti);
+}
+
+// ----------------------------------------------------------------------------
+Frame::Key Frame::key(PyObject *frame)
+{
+#if PY_VERSION_HEX >= 0x030d0000
+  _PyInterpreterFrame *iframe = (_PyInterpreterFrame *)frame;
+  const int lasti = _PyInterpreterFrame_LASTI(iframe);
+  PyCodeObject *code = (PyCodeObject *)iframe->f_executable;
+#elif PY_VERSION_HEX >= 0x030b0000
+  const _PyInterpreterFrame *iframe = (_PyInterpreterFrame *)frame;
+  const int lasti = _PyInterpreterFrame_LASTI(iframe);
+  PyCodeObject *code = iframe->f_code;
+#else
+  const PyFrameObject *py_frame = (PyFrameObject *)frame;
+  const int lasti = py_frame->f_lasti;
+  PyCodeObject *code = py_frame->f_code;
+#endif
+  return key(code, lasti);
+}
+
+// ------------------------------------------------------------------------
+#if PY_VERSION_HEX >= 0x030b0000
+Frame &Frame::read(_PyInterpreterFrame *frame_addr, _PyInterpreterFrame **prev_addr)
+#else
+Frame &Frame::read(PyObject *frame_addr, PyObject **prev_addr)
+#endif
+{
+#if PY_VERSION_HEX >= 0x030b0000
+    _PyInterpreterFrame iframe;
+#if PY_VERSION_HEX >= 0x030d0000
+    // From Python versions 3.13, f_executable can have objects other than
+    // code objects for an internal frame. We need to skip some frames if
+    // its f_executable is not code as suggested here:
+    // https://github.com/python/cpython/issues/100987#issuecomment-1485556487
+    PyObject f_executable;
+
+    for (; frame_addr; frame_addr = frame_addr->previous)
+    {
+        auto resolved_addr = stack_chunk ? reinterpret_cast<_PyInterpreterFrame *>(stack_chunk->resolve(frame_addr)) : frame_addr;
+        if (resolved_addr != frame_addr)
+        {
+            frame_addr = resolved_addr;
+        }
+        else
+        {
+            if (copy_type(frame_addr, iframe))
+            {
+                throw Frame::Error();
+            }
+            frame_addr = &iframe;
+        }
+        if (copy_type(frame_addr->f_executable, f_executable))
+        {
+            throw Frame::Error();
+        }
+        if (f_executable.ob_type == &PyCode_Type) {
+            break;
+        }
+    }
+
+    if (frame_addr == NULL) {
+        throw Frame::Error();
+    }
+#else
+    if (copy_type(frame_addr, iframe))
+        throw Error();
+    frame_addr = &iframe;
+#endif // PY_VERSION_HEX >= 0x030d0000
+
+    // We cannot use _PyInterpreterFrame_LASTI because _PyCode_CODE reads
+    // from the code object.
+#if PY_VERSION_HEX >= 0x030d0000
+    const int lasti = ((int)(frame_addr->instr_ptr - 1 - (_Py_CODEUNIT *)((PyCodeObject *)frame_addr->f_executable))) - offsetof(PyCodeObject, co_code_adaptive) / sizeof(_Py_CODEUNIT);
+    auto &frame = Frame::get((PyCodeObject *)frame_addr->f_executable, lasti);
+#else
+    const int lasti = ((int)(frame_addr->prev_instr - (_Py_CODEUNIT *)(frame_addr->f_code))) - offsetof(PyCodeObject, co_code_adaptive) / sizeof(_Py_CODEUNIT);
+    auto &frame = Frame::get(frame_addr->f_code, lasti);
+#endif // PY_VERSION_HEX >= 0x030d0000
+    if (&frame != &INVALID_FRAME)
+    {
+#if PY_VERSION_HEX >= 0x030c0000
+        frame.is_entry = (frame_addr->owner == FRAME_OWNED_BY_CSTACK); // Shim frame
+#else
+        frame.is_entry = frame_addr->is_entry;
+#endif
+    }
+
+    *prev_addr = &frame == &INVALID_FRAME ? NULL : frame_addr->previous;
+
+#else // Python < 3.11
+    // Unwind the stack from leaf to root and store it in a stack. This way we
+    // can print it from root to leaf.
+    PyFrameObject py_frame;
+
+    if (copy_type(frame_addr, py_frame))
+        throw Error();
+
+    auto &frame = Frame::get(py_frame.f_code, py_frame.f_lasti);
+
+    *prev_addr = (&frame == &INVALID_FRAME) ? NULL : (PyObject *)py_frame.f_back;
+#endif
+
+    return frame;
+}
+
+// ----------------------------------------------------------------------------
+Frame &Frame::get(PyCodeObject *code_addr, int lasti)
+{
+    auto frame_key = Frame::key(code_addr, lasti);
+
+    try
+    {
+        return frame_cache->lookup(frame_key);
+    }
+    catch (LRUCache<uintptr_t, Frame>::LookupError &)
+    {
+        try
+        {
+            PyCodeObject code;
+            if (copy_type(code_addr, code))
+              return INVALID_FRAME;
+
+            auto new_frame = std::make_unique<Frame>(&code, lasti);
+            new_frame->cache_key = frame_key;
+            auto &f = *new_frame;
+            mojo.frame(
+                frame_key,
+                new_frame->filename,
+                new_frame->name,
+                new_frame->location.line, new_frame->location.line_end,
+                new_frame->location.column, new_frame->location.column_end);
+            frame_cache->store(frame_key, std::move(new_frame));
+            return f;
+        }
+        catch (Frame::Error &)
+        {
+            return INVALID_FRAME;
+        }
+    }
+}
+
+// ----------------------------------------------------------------------------
+Frame &Frame::get(PyObject *frame)
+{
+    auto frame_key = Frame::key(frame);
+
+    try
+    {
+        return frame_cache->lookup(frame_key);
+    }
+    catch (LRUCache<uintptr_t, Frame>::LookupError &)
+    {
+        auto new_frame = std::make_unique<Frame>(frame);
+        new_frame->cache_key = frame_key;
+        auto &f = *new_frame;
+        mojo.frame(
+            frame_key,
+            new_frame->filename,
+            new_frame->name,
+            new_frame->location.line, new_frame->location.line_end,
+            new_frame->location.column, new_frame->location.column_end);
+        frame_cache->store(frame_key, std::move(new_frame));
+        return f;
+    }
+}
+
+// ----------------------------------------------------------------------------
+#ifndef UNWIND_NATIVE_DISABLE
+Frame &Frame::get(unw_cursor_t &cursor)
+{
+    unw_word_t pc;
+    unw_get_reg(&cursor, UNW_REG_IP, &pc);
+    if (pc == 0)
+        throw Error();
+
+    uintptr_t frame_key = (uintptr_t)pc;
+    try
+    {
+        return frame_cache->lookup(frame_key);
+    }
+    catch (LRUCache<uintptr_t, Frame>::LookupError &)
+    {
+        try
+        {
+            auto frame = std::make_unique<Frame>(cursor, pc);
+            frame->cache_key = frame_key;
+            auto &f = *frame;
+            mojo.frame(
+                frame_key,
+                frame->filename,
+                frame->name,
+                frame->location.line, frame->location.line_end,
+                frame->location.column, frame->location.column_end);
+            frame_cache->store(frame_key, std::move(frame));
+            return f;
+        }
+        catch (Frame::Error &)
+        {
+            return UNKNOWN_FRAME;
+        }
+    }
+}
+#endif // UNWIND_NATIVE_DISABLE
+
+// ----------------------------------------------------------------------------
+Frame &Frame::get(StringTable::Key name)
+{
+    uintptr_t frame_key = (uintptr_t)name;
+    try
+    {
+        return frame_cache->lookup(frame_key);
+    }
+    catch (LRUCache<uintptr_t, Frame>::LookupError &)
+    {
+        auto frame = std::make_unique<Frame>(name);
+        frame->cache_key = frame_key;
+        auto &f = *frame;
+        mojo.frame(
+            frame_key,
+            frame->filename,
+            frame->name,
+            frame->location.line, frame->location.line_end,
+            frame->location.column, frame->location.column_end);
+        frame_cache->store(frame_key, std::move(frame));
+        return f;
+    }
+}

--- a/echion/frame.h
+++ b/echion/frame.h
@@ -6,6 +6,9 @@
 
 #define PY_SSIZE_T_CLEAN
 #include <Python.h>
+#if defined __GNUC__ && defined HAVE_STD_ATOMIC
+#undef HAVE_STD_ATOMIC
+#endif
 #if PY_VERSION_HEX >= 0x030c0000
 // https://github.com/python/cpython/issues/108216#issuecomment-1696565797
 #undef _PyGC_FINALIZED

--- a/echion/frame.h
+++ b/echion/frame.h
@@ -86,6 +86,14 @@ public:
     bool is_entry = false;
 #endif
 
+    // ------------------------------------------------------------------------
+    Frame(StringTable::Key name) : name(name) {};
+    Frame(PyObject *frame);
+    Frame(PyCodeObject *code, int lasti);
+#ifndef UNWIND_NATIVE_DISABLE
+    Frame(unw_cursor_t &cursor, unw_word_t pc);
+#endif // UNWIND_NATIVE_DISABLE
+
 #if PY_VERSION_HEX >= 0x030b0000
     static Frame &read(_PyInterpreterFrame *frame_addr, _PyInterpreterFrame **prev_addr);
 #else
@@ -98,13 +106,6 @@ public:
     static Frame &get(unw_cursor_t &cursor);
 #endif // UNWIND_NATIVE_DISABLE
     static Frame &get(StringTable::Key name);
-
-    Frame(StringTable::Key name) : name(name) {};
-    Frame(PyObject *frame);
-    Frame(PyCodeObject *code, int lasti);
-#ifndef UNWIND_NATIVE_DISABLE
-    Frame(unw_cursor_t &cursor, unw_word_t pc);
-#endif // UNWIND_NATIVE_DISABLE
 
     void render_where(std::ostream &stream);
 

--- a/echion/frame.h
+++ b/echion/frame.h
@@ -6,11 +6,17 @@
 
 #define PY_SSIZE_T_CLEAN
 #include <Python.h>
+#if PY_VERSION_HEX >= 0x030c0000
+// https://github.com/python/cpython/issues/108216#issuecomment-1696565797
+#undef _PyGC_FINALIZED
+#endif
 #include <frameobject.h>
 #if PY_VERSION_HEX >= 0x030d0000
+#define Py_BUILD_CORE
 #include <internal/pycore_code.h>
 #endif // PY_VERSION_HEX >= 0x030d0000
 #if PY_VERSION_HEX >= 0x030b0000
+#define Py_BUILD_CORE
 #include <internal/pycore_frame.h>
 #endif
 
@@ -34,34 +40,6 @@
 #endif // PY_VERSION_HEX >= 0x030b0000
 #include <echion/strings.h>
 #include <echion/vm.h>
-
-// ----------------------------------------------------------------------------
-#if PY_VERSION_HEX >= 0x030b0000
-static inline int
-_read_varint(unsigned char *table, ssize_t size, ssize_t *i)
-{
-    ssize_t guard = size - 1;
-    if (*i >= guard)
-        return 0;
-
-    int val = table[++*i] & 63;
-    int shift = 0;
-    while (table[*i] & 64 && *i < guard)
-    {
-        shift += 6;
-        val |= (table[++*i] & 63) << shift;
-    }
-    return val;
-}
-
-// ----------------------------------------------------------------------------
-static inline int
-_read_signed_varint(unsigned char *table, ssize_t size, ssize_t *i)
-{
-    int val = _read_varint(table, size, i);
-    return (val & 1) ? -(val >> 1) : (val >> 1);
-}
-#endif
 
 // ----------------------------------------------------------------------------
 class Frame
@@ -92,7 +70,6 @@ public:
     };
 
     // ------------------------------------------------------------------------
-
     Key cache_key = 0;
     StringTable::Key filename = 0;
     StringTable::Key name = 0;
@@ -109,10 +86,6 @@ public:
     bool is_entry = false;
 #endif
 
-    // ------------------------------------------------------------------------
-
-    Frame(StringTable::Key name) : name(name) {};
-
 #if PY_VERSION_HEX >= 0x030b0000
     static Frame &read(_PyInterpreterFrame *frame_addr, _PyInterpreterFrame **prev_addr);
 #else
@@ -126,468 +99,26 @@ public:
 #endif // UNWIND_NATIVE_DISABLE
     static Frame &get(StringTable::Key name);
 
-    // ------------------------------------------------------------------------
-    Frame(PyObject *frame)
-    {
-#if PY_VERSION_HEX >= 0x030b0000
-
-#if PY_VERSION_HEX >= 0x030d0000
-        _PyInterpreterFrame* iframe = (_PyInterpreterFrame *)frame;
-        const int lasti = _PyInterpreterFrame_LASTI(iframe);
-        PyCodeObject* code = (PyCodeObject*)iframe->f_executable;
-#else
-        const _PyInterpreterFrame *iframe = (_PyInterpreterFrame *)frame;
-        const int lasti = _PyInterpreterFrame_LASTI(iframe);
-        PyCodeObject *code = iframe->f_code;
-#endif // PY_VERSION_HEX >= 0x030d0000
-        PyCode_Addr2Location(code, lasti << 1, &location.line, &location.column, &location.line_end, &location.column_end);
-        location.column++;
-        location.column_end++;
-        name = string_table.key_unsafe(code->co_qualname);
-#if PY_VERSION_HEX >= 0x030c0000
-        is_entry = (iframe->owner == FRAME_OWNED_BY_CSTACK); // Shim frame
-#else
-        is_entry = iframe->is_entry;
-#endif
-
-#else
-        PyFrameObject *py_frame = (PyFrameObject *)frame;
-        PyCodeObject *code = py_frame->f_code;
-
-        location.line = PyFrame_GetLineNumber(py_frame);
-        name = string_table.key_unsafe(code->co_name);
-#endif
-        filename = string_table.key_unsafe(code->co_filename);
-    }
-
-    // ------------------------------------------------------------------------
-    Frame(PyCodeObject *code, int lasti)
-    {
-        try
-        {
-            filename = string_table.key(code->co_filename);
-#if PY_VERSION_HEX >= 0x030b0000
-            name = string_table.key(code->co_qualname);
-#else
-            name = string_table.key(code->co_name);
-#endif
-        }
-        catch (StringTable::Error &)
-        {
-            throw Error();
-        }
-
-        infer_location(code, lasti);
-    }
-
-    // ------------------------------------------------------------------------
+    Frame(StringTable::Key name) : name(name) {};
+    Frame(PyObject *frame);
+    Frame(PyCodeObject *code, int lasti);
 #ifndef UNWIND_NATIVE_DISABLE
-    Frame(unw_cursor_t &cursor, unw_word_t pc)
-    {
-        try
-        {
-            filename = string_table.key(pc);
-            name = string_table.key(cursor);
-        }
-        catch (StringTable::Error &)
-        {
-            throw Error();
-        }
-    }
+    Frame(unw_cursor_t &cursor, unw_word_t pc);
 #endif // UNWIND_NATIVE_DISABLE
 
-    // ------------------------------------------------------------------------
-    void render_where(std::ostream &stream)
-    {
-        if ((string_table.lookup(filename)).rfind("native@", 0) == 0)
-            stream << "          \033[38;5;248;1m" << string_table.lookup(name)
-            << "\033[0m \033[38;5;246m(" << string_table.lookup(filename)
-            << "\033[0m:\033[38;5;246m" << location.line
-            << ")\033[0m" << std::endl;
-        else
-            stream << "          \033[33;1m" << string_table.lookup(name)
-            << "\033[0m (\033[36m" << string_table.lookup(filename)
-            << "\033[0m:\033[32m" << location.line
-            << "\033[0m)" << std::endl;
-    }
+    void render_where(std::ostream &stream);
 
 private:
-    // ------------------------------------------------------------------------
-    void inline infer_location(PyCodeObject *code, int lasti)
-    {
-        unsigned int lineno = code->co_firstlineno;
-        Py_ssize_t len = 0;
-
-#if PY_VERSION_HEX >= 0x030b0000
-        auto table = pybytes_to_bytes_and_size(code->co_linetable, &len);
-        if (table == nullptr)
-            throw LocationError();
-
-        auto table_data = table.get();
-
-        for (Py_ssize_t i = 0, bc = 0; i < len; i++)
-        {
-            bc += (table[i] & 7) + 1;
-            int code = (table[i] >> 3) & 15;
-            unsigned char next_byte = 0;
-            switch (code)
-            {
-            case 15:
-                break;
-
-            case 14: // Long form
-                lineno += _read_signed_varint(table_data, len, &i);
-
-                this->location.line = lineno;
-                this->location.line_end = lineno + _read_varint(table_data, len, &i);
-                this->location.column = _read_varint(table_data, len, &i);
-                this->location.column_end = _read_varint(table_data, len, &i);
-
-                break;
-
-            case 13: // No column data
-                lineno += _read_signed_varint(table_data, len, &i);
-
-                this->location.line = lineno;
-                this->location.line_end = lineno;
-                this->location.column = this->location.column_end = 0;
-
-                break;
-
-            case 12: // New lineno
-            case 11:
-            case 10:
-                if (i >= len - 2)
-                    throw LocationError();
-
-                lineno += code - 10;
-
-                this->location.line = lineno;
-                this->location.line_end = lineno;
-                this->location.column = 1 + table[++i];
-                this->location.column_end = 1 + table[++i];
-
-                break;
-
-            default:
-                if (i >= len - 1)
-                    throw LocationError();
-
-                next_byte = table[++i];
-
-                this->location.line = lineno;
-                this->location.line_end = lineno;
-                this->location.column = 1 + (code << 3) + ((next_byte >> 4) & 7);
-                this->location.column_end = this->location.column + (next_byte & 15);
-            }
-
-            if (bc > lasti)
-                break;
-        }
-
-#elif PY_VERSION_HEX >= 0x030a0000
-        auto table = pybytes_to_bytes_and_size(code->co_linetable, &len);
-        if (table == nullptr)
-            throw LocationError();
-
-        lasti <<= 1;
-        for (int i = 0, bc = 0; i < len; i++)
-        {
-            int sdelta = table[i++];
-            if (sdelta == 0xff)
-                break;
-
-            bc += sdelta;
-
-            int ldelta = table[i];
-            if (ldelta == 0x80)
-                ldelta = 0;
-            else if (ldelta > 0x80)
-                lineno -= 0x100;
-
-            lineno += ldelta;
-            if (bc > lasti)
-                break;
-        }
-
-#else
-        auto table = pybytes_to_bytes_and_size(code->co_lnotab, &len);
-        if (table == nullptr)
-            throw LocationError();
-
-        for (int i = 0, bc = 0; i < len; i++)
-        {
-            bc += table[i++];
-            if (bc > lasti)
-                break;
-
-            if (table[i] >= 0x80)
-                lineno -= 0x100;
-
-            lineno += table[i];
-        }
-
-#endif
-
-        this->location.line = lineno;
-        this->location.line_end = lineno;
-        this->location.column = 0;
-        this->location.column_end = 0;
-    }
-
-    // ------------------------------------------------------------------------
-    static inline Key key(PyCodeObject *code, int lasti)
-    {
-        return (((uintptr_t)(((uintptr_t)code) & MOJO_INT32) << 16) | lasti);
-    }
-
-    // ------------------------------------------------------------------------
-    static inline Key key(PyObject *frame)
-    {
-
-#if PY_VERSION_HEX >= 0x030d0000
-        _PyInterpreterFrame *iframe = (_PyInterpreterFrame *)frame;
-        const int lasti = _PyInterpreterFrame_LASTI(iframe);
-        PyCodeObject* code = (PyCodeObject*)iframe->f_executable;
-#elif PY_VERSION_HEX >= 0x030b0000
-        const _PyInterpreterFrame *iframe = (_PyInterpreterFrame *)frame;
-        const int lasti = _PyInterpreterFrame_LASTI(iframe);
-        PyCodeObject *code = iframe->f_code;
-#else
-        const PyFrameObject *py_frame = (PyFrameObject *)frame;
-        const int lasti = py_frame->f_lasti;
-        PyCodeObject *code = py_frame->f_code;
-#endif
-        return key(code, lasti);
-    }
+    void inline infer_location(PyCodeObject *code, int lasti);
+    static inline Key key(PyCodeObject *code, int lasti);
+    static inline Key key(PyObject *frame);
 };
 
-// ----------------------------------------------------------------------------
-
-static auto INVALID_FRAME = Frame(StringTable::INVALID);
-static auto UNKNOWN_FRAME = Frame(StringTable::UNKNOWN);
+inline auto INVALID_FRAME = Frame(StringTable::INVALID);
+inline auto UNKNOWN_FRAME = Frame(StringTable::UNKNOWN);
 
 // We make this a raw pointer to prevent its destruction on exit, since we
 // control the lifetime of the cache.
-static LRUCache<uintptr_t, Frame> *frame_cache = nullptr;
-
-// ----------------------------------------------------------------------------
-static void init_frame_cache(size_t capacity)
-{
-    frame_cache = new LRUCache<uintptr_t, Frame>(capacity);
-}
-
-// ----------------------------------------------------------------------------
-static void reset_frame_cache()
-{
-    delete frame_cache;
-    frame_cache = nullptr;
-}
-
-// ------------------------------------------------------------------------
-#if PY_VERSION_HEX >= 0x030b0000
-Frame &Frame::read(_PyInterpreterFrame *frame_addr, _PyInterpreterFrame **prev_addr)
-#else
-Frame &Frame::read(PyObject *frame_addr, PyObject **prev_addr)
-#endif
-{
-#if PY_VERSION_HEX >= 0x030b0000
-    _PyInterpreterFrame iframe;
-#if PY_VERSION_HEX >= 0x030d0000
-    // From Python versions 3.13, f_executable can have objects other than
-    // code objects for an internal frame. We need to skip some frames if
-    // its f_executable is not code as suggested here:
-    // https://github.com/python/cpython/issues/100987#issuecomment-1485556487
-    PyObject f_executable;
-
-    for (; frame_addr; frame_addr = frame_addr->previous)
-    {
-        auto resolved_addr = stack_chunk ? reinterpret_cast<_PyInterpreterFrame *>(stack_chunk->resolve(frame_addr)) : frame_addr;
-        if (resolved_addr != frame_addr)
-        {
-            frame_addr = resolved_addr;
-        }
-        else
-        {
-            if (copy_type(frame_addr, iframe))
-            {
-                throw Frame::Error();
-            }
-            frame_addr = &iframe;
-        }
-        if (copy_type(frame_addr->f_executable, f_executable))
-        {
-            throw Frame::Error();
-        }
-        if (f_executable.ob_type == &PyCode_Type) {
-            break;
-        }
-    }
-
-    if (frame_addr == NULL) {
-        throw Frame::Error();
-    }
-#else
-    if (copy_type(frame_addr, iframe))
-        throw Error();
-    frame_addr = &iframe;
-#endif // PY_VERSION_HEX >= 0x030d0000
-
-    // We cannot use _PyInterpreterFrame_LASTI because _PyCode_CODE reads
-    // from the code object.
-#if PY_VERSION_HEX >= 0x030d0000
-    const int lasti = ((int)(frame_addr->instr_ptr - 1 - (_Py_CODEUNIT *)((PyCodeObject *)frame_addr->f_executable))) - offsetof(PyCodeObject, co_code_adaptive) / sizeof(_Py_CODEUNIT);
-    auto &frame = Frame::get((PyCodeObject *)frame_addr->f_executable, lasti);
-#else
-    const int lasti = ((int)(frame_addr->prev_instr - (_Py_CODEUNIT *)(frame_addr->f_code))) - offsetof(PyCodeObject, co_code_adaptive) / sizeof(_Py_CODEUNIT);
-    auto &frame = Frame::get(frame_addr->f_code, lasti);
-#endif // PY_VERSION_HEX >= 0x030d0000
-    if (&frame != &INVALID_FRAME)
-    {
-#if PY_VERSION_HEX >= 0x030c0000
-        frame.is_entry = (frame_addr->owner == FRAME_OWNED_BY_CSTACK); // Shim frame
-#else
-        frame.is_entry = frame_addr->is_entry;
-#endif
-    }
-
-    *prev_addr = &frame == &INVALID_FRAME ? NULL : frame_addr->previous;
-
-#else // Python < 3.11
-    // Unwind the stack from leaf to root and store it in a stack. This way we
-    // can print it from root to leaf.
-    PyFrameObject py_frame;
-
-    if (copy_type(frame_addr, py_frame))
-        throw Error();
-
-    auto &frame = Frame::get(py_frame.f_code, py_frame.f_lasti);
-
-    *prev_addr = (&frame == &INVALID_FRAME) ? NULL : (PyObject *)py_frame.f_back;
-#endif
-
-    return frame;
-}
-
-// ----------------------------------------------------------------------------
-Frame &Frame::get(PyCodeObject *code_addr, int lasti)
-{
-    auto frame_key = Frame::key(code_addr, lasti);
-
-    try
-    {
-        return frame_cache->lookup(frame_key);
-    }
-    catch (LRUCache<uintptr_t, Frame>::LookupError &)
-    {
-        try
-        {
-            PyCodeObject code;
-            if (copy_type(code_addr, code))
-              return INVALID_FRAME;
-
-            auto new_frame = std::make_unique<Frame>(&code, lasti);
-            new_frame->cache_key = frame_key;
-            auto &f = *new_frame;
-            mojo.frame(
-                frame_key,
-                new_frame->filename,
-                new_frame->name,
-                new_frame->location.line, new_frame->location.line_end,
-                new_frame->location.column, new_frame->location.column_end);
-            frame_cache->store(frame_key, std::move(new_frame));
-            return f;
-        }
-        catch (Frame::Error &)
-        {
-            return INVALID_FRAME;
-        }
-    }
-}
-
-// ----------------------------------------------------------------------------
-Frame &Frame::get(PyObject *frame)
-{
-    auto frame_key = Frame::key(frame);
-
-    try
-    {
-        return frame_cache->lookup(frame_key);
-    }
-    catch (LRUCache<uintptr_t, Frame>::LookupError &)
-    {
-        auto new_frame = std::make_unique<Frame>(frame);
-        new_frame->cache_key = frame_key;
-        auto &f = *new_frame;
-        mojo.frame(
-            frame_key,
-            new_frame->filename,
-            new_frame->name,
-            new_frame->location.line, new_frame->location.line_end,
-            new_frame->location.column, new_frame->location.column_end);
-        frame_cache->store(frame_key, std::move(new_frame));
-        return f;
-    }
-}
-
-// ----------------------------------------------------------------------------
-#ifndef UNWIND_NATIVE_DISABLE
-Frame &Frame::get(unw_cursor_t &cursor)
-{
-    unw_word_t pc;
-    unw_get_reg(&cursor, UNW_REG_IP, &pc);
-    if (pc == 0)
-        throw Error();
-
-    uintptr_t frame_key = (uintptr_t)pc;
-    try
-    {
-        return frame_cache->lookup(frame_key);
-    }
-    catch (LRUCache<uintptr_t, Frame>::LookupError &)
-    {
-        try
-        {
-            auto frame = std::make_unique<Frame>(cursor, pc);
-            frame->cache_key = frame_key;
-            auto &f = *frame;
-            mojo.frame(
-                frame_key,
-                frame->filename,
-                frame->name,
-                frame->location.line, frame->location.line_end,
-                frame->location.column, frame->location.column_end);
-            frame_cache->store(frame_key, std::move(frame));
-            return f;
-        }
-        catch (Frame::Error &)
-        {
-            return UNKNOWN_FRAME;
-        }
-    }
-}
-#endif // UNWIND_NATIVE_DISABLE
-
-// ----------------------------------------------------------------------------
-Frame &Frame::get(StringTable::Key name)
-{
-    uintptr_t frame_key = (uintptr_t)name;
-    try
-    {
-        return frame_cache->lookup(frame_key);
-    }
-    catch (LRUCache<uintptr_t, Frame>::LookupError &)
-    {
-        auto frame = std::make_unique<Frame>(name);
-        frame->cache_key = frame_key;
-        auto &f = *frame;
-        mojo.frame(
-            frame_key,
-            frame->filename,
-            frame->name,
-            frame->location.line, frame->location.line_end,
-            frame->location.column, frame->location.column_end);
-        frame_cache->store(frame_key, std::move(frame));
-        return f;
-    }
-}
+inline LRUCache<uintptr_t, Frame> *frame_cache = nullptr;
+void init_frame_cache(size_t capacity);
+void reset_frame_cache();

--- a/echion/memory.h
+++ b/echion/memory.h
@@ -203,8 +203,8 @@ private:
 // We make this a reference to a heap-allocated object so that we can avoid
 // the destruction on exit. We are in charge of cleaning up the object. Note
 // that the object will leak, but this is not a problem.
-static auto &stack_stats = *(new StackStats());
-static auto &memory_table = *(new MemoryTable());
+inline auto &stack_stats = *(new StackStats());
+inline auto &memory_table = *(new MemoryTable());
 
 // ----------------------------------------------------------------------------
 static inline void
@@ -311,8 +311,8 @@ echion_free(void *ctx, void *p)
 //      defined as an enum.
 #define ALLOC_DOMAIN_COUNT 3
 
-static PyMemAllocatorEx original_allocators[ALLOC_DOMAIN_COUNT];
-static PyMemAllocatorEx echion_allocator = {
+inline PyMemAllocatorEx original_allocators[ALLOC_DOMAIN_COUNT];
+inline PyMemAllocatorEx echion_allocator = {
     NULL,
     echion_malloc,
     echion_calloc,

--- a/echion/mojo.h
+++ b/echion/mojo.h
@@ -6,6 +6,7 @@
 
 #include <exception>
 #include <fstream>
+#include <mutex>
 #include <ostream>
 
 #define MOJO_VERSION 3

--- a/echion/mojo.h
+++ b/echion/mojo.h
@@ -222,4 +222,4 @@ private:
 
 // ----------------------------------------------------------------------------
 
-static MojoWriter mojo;
+inline MojoWriter mojo;

--- a/echion/mojo.h
+++ b/echion/mojo.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <exception>
+#include <fstream>
 #include <ostream>
 
 #define MOJO_VERSION 3

--- a/echion/signals.h
+++ b/echion/signals.h
@@ -14,7 +14,7 @@
 
 // ----------------------------------------------------------------------------
 
-static std::mutex sigprof_handler_lock;
+inline std::mutex sigprof_handler_lock;
 
 // ----------------------------------------------------------------------------
 void sigprof_handler([[maybe_unused]] int signum)

--- a/echion/stack_chunk.h
+++ b/echion/stack_chunk.h
@@ -10,6 +10,8 @@
 #include <exception>
 #include <memory>
 
+#include <echion/vm.h>
+
 // ----------------------------------------------------------------------------
 
 class StackChunkError : public std::exception
@@ -25,16 +27,16 @@ public:
 class StackChunk
 {
 public:
-  StackChunk(PyThreadState *tstate) : StackChunk((_PyStackChunk *)tstate->datastack_chunk) {}
+  inline StackChunk(PyThreadState *tstate) : StackChunk((_PyStackChunk *)tstate->datastack_chunk) {}
 
-  void *resolve(void *frame_addr);
+  inline void *resolve(void *frame_addr);
 
 private:
   void *origin = NULL;
   std::unique_ptr<char[]> data = nullptr;
   std::unique_ptr<StackChunk> previous = nullptr;
 
-  StackChunk(_PyStackChunk *chunk_addr);
+  inline StackChunk(_PyStackChunk *chunk_addr);
 };
 
 // ----------------------------------------------------------------------------

--- a/echion/stack_chunk.h
+++ b/echion/stack_chunk.h
@@ -85,4 +85,4 @@ void *StackChunk::resolve(void *address)
 
 // ----------------------------------------------------------------------------
 
-static std::unique_ptr<StackChunk> stack_chunk = nullptr;
+inline std::unique_ptr<StackChunk> stack_chunk = nullptr;

--- a/echion/stacks.h
+++ b/echion/stacks.h
@@ -64,9 +64,9 @@ private:
 
 // ----------------------------------------------------------------------------
 
-static FrameStack python_stack;
-static FrameStack native_stack;
-static FrameStack interleaved_stack;
+inline FrameStack python_stack;
+inline FrameStack native_stack;
+inline FrameStack interleaved_stack;
 
 // ----------------------------------------------------------------------------
 #ifndef UNWIND_NATIVE_DISABLE
@@ -349,4 +349,4 @@ private:
 // We make this a reference to a heap-allocated object so that we can avoid
 // the destruction on exit. We are in charge of cleaning up the object. Note
 // that the object will leak, but this is not a problem.
-static auto &stack_table = *(new StackTable());
+inline auto &stack_table = *(new StackTable());

--- a/echion/state.h
+++ b/echion/state.h
@@ -16,17 +16,17 @@
 #include <mutex>
 #include <thread>
 
-static _PyRuntimeState *runtime = &_PyRuntime;
-static PyThreadState *current_tstate = NULL;
+inline _PyRuntimeState *runtime = &_PyRuntime;
+inline PyThreadState *current_tstate = NULL;
 
-static std::thread *sampler_thread = nullptr;
+inline std::thread *sampler_thread = nullptr;
 
-static int running = 0;
+inline int running = 0;
 
-static std::thread *where_thread = nullptr;
-static std::condition_variable where_cv;
-static std::mutex where_lock;
+inline std::thread *where_thread = nullptr;
+inline std::condition_variable where_cv;
+inline std::mutex where_lock;
 
-static PyObject *asyncio_current_tasks = NULL;
-static PyObject *asyncio_scheduled_tasks = NULL; // WeakSet
-static PyObject *asyncio_eager_tasks = NULL;     // set
+inline PyObject *asyncio_current_tasks = NULL;
+inline PyObject *asyncio_scheduled_tasks = NULL; // WeakSet
+inline PyObject *asyncio_eager_tasks = NULL;     // set

--- a/echion/strings.h
+++ b/echion/strings.h
@@ -229,4 +229,4 @@ public:
 // We make this a reference to a heap-allocated object so that we can avoid
 // the destruction on exit. We are in charge of cleaning up the object. Note
 // that the object will leak, but this is not a problem.
-static StringTable &string_table = *(new StringTable());
+inline StringTable &string_table = *(new StringTable());

--- a/echion/tasks.h
+++ b/echion/tasks.h
@@ -148,8 +148,8 @@ public:
     inline size_t unwind(FrameStack &);
 };
 
-static std::unordered_map<PyObject *, PyObject *> task_link_map;
-static std::mutex task_link_map_lock;
+inline std::unordered_map<PyObject *, PyObject *> task_link_map;
+inline std::mutex task_link_map_lock;
 
 // ----------------------------------------------------------------------------
 TaskInfo::TaskInfo(TaskObj *task_addr)
@@ -276,7 +276,7 @@ get_all_tasks(PyObject *loop)
 
 // ----------------------------------------------------------------------------
 
-static std::vector<std::unique_ptr<FrameStack>> current_tasks;
+inline std::vector<std::unique_ptr<FrameStack>> current_tasks;
 
 // ----------------------------------------------------------------------------
 

--- a/echion/threads.h
+++ b/echion/threads.h
@@ -162,10 +162,10 @@ bool ThreadInfo::is_running()
 // We make this a reference to a heap-allocated object so that we can avoid
 // the destruction on exit. We are in charge of cleaning up the object. Note
 // that the object will leak, but this is not a problem.
-static std::unordered_map<uintptr_t, ThreadInfo::Ptr> &thread_info_map =
+inline std::unordered_map<uintptr_t, ThreadInfo::Ptr> &thread_info_map =
     *(new std::unordered_map<uintptr_t, ThreadInfo::Ptr>()); // indexed by thread_id
 
-static std::mutex thread_info_map_lock;
+inline std::mutex thread_info_map_lock;
 
 // ----------------------------------------------------------------------------
 void ThreadInfo::unwind(PyThreadState *tstate)

--- a/echion/timing.h
+++ b/echion/timing.h
@@ -10,12 +10,12 @@
 #include <mach/clock.h>
 #include <mach/mach.h>
 
-static clock_serv_t cclock;
+inline clock_serv_t cclock;
 #endif
 
 typedef unsigned long microsecond_t;
 
-static microsecond_t last_time = 0;
+inline microsecond_t last_time = 0;
 
 #define TS_TO_MICROSECOND(ts) ((ts).tv_sec * 1e6 + (ts).tv_nsec / 1e3)
 #define TV_TO_MICROSECOND(tv) ((tv).seconds * 1e6 + (tv).microseconds)

--- a/echion/vm.h
+++ b/echion/vm.h
@@ -48,7 +48,7 @@ typedef mach_port_t proc_ref_t;
 inline bool failed_safe_copy = false;
 
 #if defined PL_LINUX
-ssize_t (*safe_copy)(pid_t, const struct iovec *, unsigned long, const struct iovec *, unsigned long, unsigned long) = process_vm_readv;
+inline ssize_t (*safe_copy)(pid_t, const struct iovec *, unsigned long, const struct iovec *, unsigned long, unsigned long) = process_vm_readv;
 
 class VmReader
 {
@@ -187,13 +187,13 @@ public:
 /**
  * Initialize the safe copy operation on Linux
  */
-bool read_process_vm_init()
+inline bool read_process_vm_init()
 {
     VmReader *_ = VmReader::get_instance();
     return !!_;
 }
 
-ssize_t vmreader_safe_copy(pid_t pid,
+inline ssize_t vmreader_safe_copy(pid_t pid,
                            const struct iovec *local_iov, unsigned long liovcnt,
                            const struct iovec *remote_iov, unsigned long riovcnt, unsigned long flags)
 {
@@ -208,7 +208,7 @@ ssize_t vmreader_safe_copy(pid_t pid,
  *
  * This occurs at static init
  */
-__attribute__((constructor)) void init_safe_copy()
+__attribute__((constructor)) inline void init_safe_copy()
 {
     char src[128];
     char dst[128];
@@ -298,7 +298,7 @@ static inline int copy_memory(proc_ref_t proc_ref, void *addr, ssize_t len, void
     return len != result;
 }
 
-static pid_t pid = 0;
+inline pid_t pid = 0;
 
 inline void _set_pid(pid_t _pid) {
     pid = _pid;

--- a/echion/vm.h
+++ b/echion/vm.h
@@ -45,7 +45,7 @@ typedef mach_port_t proc_ref_t;
 #endif
 
 // Some checks are done at static initialization, so use this to read them at runtime
-bool failed_safe_copy = false;
+inline bool failed_safe_copy = false;
 
 #if defined PL_LINUX
 ssize_t (*safe_copy)(pid_t, const struct iovec *, unsigned long, const struct iovec *, unsigned long, unsigned long) = process_vm_readv;
@@ -300,6 +300,6 @@ static inline int copy_memory(proc_ref_t proc_ref, void *addr, ssize_t len, void
 
 static pid_t pid = 0;
 
-void _set_pid(pid_t _pid) {
+inline void _set_pid(pid_t _pid) {
     pid = _pid;
 }

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ if DISABLE_NATIVE:
 
 echionmodule = Extension(
     "echion.core",
-    sources=["echion/coremodule.cc"],
+    sources=["echion/coremodule.cc", "echion/frame.cc"],
     include_dirs=["."],
     define_macros=[(f"PL_{PLATFORM.upper()}", None)],
     extra_compile_args=["-std=c++17", "-Wall", "-Wextra"] + CFLAGS + COLORS,


### PR DESCRIPTION
- Splits `frame.h` into header and `.cc` files to avoid circular dependency between `render.h` and `frame.h` as in #67, this also resulted in some cascading changes in other headers to update their `#include`s
- Use `inline` instead of `static` for global variables, as now we have multiple `.cc` files including those headers. Using `static` leads to having own copies of such variables in those `.cc` files. 
