### PR TITLE
use a sigtrap-based memory reader

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,9 +17,9 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
-        echion-alt-vm-force: ["1", "0"]
+        echion-vm-read-mode: ["0", "1", "2"]
 
-    name: Tests with Python ${{ matrix.python-version }}, ECHION_ALT_VM_FORCE=${{ matrix.echion-alt-vm-force }} on ubuntu-latest
+    name: Tests with Python ${{ matrix.python-version }}, ECHION_VM_READ_MODE=${{ matrix.echion-vm-read-mode }} on ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 
@@ -41,12 +41,12 @@ jobs:
         run: |
           ulimit -c unlimited
           echo "core.%p" | sudo tee /proc/sys/kernel/core_pattern
-          sudo -E env PATH="$PATH" ECHION_ALT_VM_READ_FORCE=${{ matrix.echion-alt-vm-force }} hatch run tests.py${{ matrix.python-version }}:tests -svv
+          sudo -E env PATH="$PATH" ECHION_VM_READ_MODE=${{ matrix.echion-vm-read-mode }} hatch run tests.py${{ matrix.python-version }}:tests -svv
 
       - name: Upload profiles
         uses: actions/upload-artifact@v4
         with:
-          name: profiles-${{ runner.os }}-${{ matrix.python-version }}-${{ matrix.echion-alt-vm-force }}
+          name: profiles-${{ runner.os }}-${{ matrix.python-version }}-${{ matrix.echion-vm-read-mode }}
           path: profiles/
           overwrite: true
         if: always()
@@ -88,7 +88,7 @@ jobs:
 
       - name: Run tests
         run: sudo -E hatch run tests.py${{ matrix.python-version }}:tests -svv
-  
+
       - name: Upload profiles
         uses: actions/upload-artifact@v4
         with:

--- a/echion/bootstrap/__init__.py
+++ b/echion/bootstrap/__init__.py
@@ -36,6 +36,7 @@ def start():
     ec.set_native(bool(int(os.getenv("ECHION_NATIVE", 0))))
     ec.set_where(bool(int(os.getenv("ECHION_WHERE", 0) or 0)))
     ec.set_max_fds(int(os.getenv("ECHION_MAX_FDS", 16)))
+    ec.set_vm_read_mode(int(os.getenv("ECHION_VM_READ_MODE", 0)))
 
     # Monkey-patch the standard library on import
     try:

--- a/echion/config.h
+++ b/echion/config.h
@@ -39,6 +39,13 @@ inline unsigned int max_fds = 16;
 // Pipe name (where mode IPC)
 inline std::string pipe_name;
 
+// Which VM reading mode to use
+// 1 - process_vm_readv (default)
+// 2 - sigtrap
+// -1 - error (cannot be set by user)
+// else - writev (failover)
+inline int vm_read_mode = 1;
+
 // ----------------------------------------------------------------------------
 static PyObject *
 set_interval(PyObject *Py_UNUSED(m), PyObject *args)

--- a/echion/coremodule.cc
+++ b/echion/coremodule.cc
@@ -433,6 +433,7 @@ static PyMethodDef echion_core_methods[] = {
     {"set_where", set_where, METH_VARARGS, "Set whether to use where mode"},
     {"set_pipe_name", set_pipe_name, METH_VARARGS, "Set the pipe name"},
     {"set_max_fds", set_max_fds, METH_VARARGS, "Set the maximum number of file descriptors to use"},
+    {"set_vm_read_mode", set_vm_read_mode, METH_VARARGS, "Set the virtual memory read mode"},
     {NULL, NULL, 0, NULL} /* Sentinel */
 };
 

--- a/echion/vm.h
+++ b/echion/vm.h
@@ -360,7 +360,7 @@ inline bool init_safe_copy(int mode)
         if (read_process_vm_init()) {
             std::cerr << "VmReader initialized" << std::endl;
             safe_copy = vmreader_safe_copy;
-            return mode >= 1 && mode <= 2; // only "true" if the user had requested this mode
+            return mode != 0; // Return true IFF user had requested writev
         }
         std::cerr << "VmReader failed to initialize" << std::endl;
     }

--- a/echion/vm.h
+++ b/echion/vm.h
@@ -256,22 +256,24 @@ class VmReader
     }
 
 public:
-      static VmReader *get_instance()
-      {
-          if (instance == nullptr)
-          {
-              static std::once_flag init_flag;
-              std::call_once(init_flag, []() {
-                  // Nothing to do on failure here since instance is already null
-                  try
-                  {
-                      auto temp = new VmReader(1024 * 1024); // A megabyte?
-                      instance = temp;
-                  }
-              });
-          }
-          return instance;
-      }
+    static VmReader *get_instance()
+    {
+        if (instance == nullptr)
+        {
+            static std::once_flag init_flag;
+            std::call_once(init_flag, []() {
+                // Nothing to do on failure here since instance is already null
+                try
+                {
+                    auto temp = new VmReader(1024 * 1024); // A megabyte?
+                    instance = temp;
+                } catch(...) {
+                    // pass
+                }
+            });
+        }
+        return instance;
+    }
 
     ssize_t safe_copy(pid_t pid,
                       const struct iovec *local_iov, unsigned long liovcnt,

--- a/echion/vm.h
+++ b/echion/vm.h
@@ -7,13 +7,20 @@
 #include <array>
 #include <cstdlib>
 #include <iostream>
+#include <mutex>
+#include <limits.h>
 #include <stdexcept>
 #include <string>
 
+#define PL_LINUX 1
 #if defined PL_LINUX
 #include <algorithm>
+#include <atomic>
+#include <cstring>
 #include <fcntl.h>
 #include <memory>
+#include <setjmp.h>
+#include <signal.h>
 #include <sys/mman.h>
 #include <sys/stat.h>
 #include <sys/types.h>
@@ -50,6 +57,68 @@ inline bool failed_safe_copy = false;
 #if defined PL_LINUX
 inline ssize_t (*safe_copy)(pid_t, const struct iovec *, unsigned long, const struct iovec *, unsigned long, unsigned long) = process_vm_readv;
 
+class TrappedVmReader {
+private:
+      static inline std::atomic<bool> unsafe_read_in_progress {false};
+      static inline jmp_buf jump_buffer;
+      static inline struct sigaction old_sigsegv_action;
+      static inline struct sigaction old_sigbus_action;
+
+    static void segfault_handler(int sig, siginfo_t *info, void *context) {
+        if (unsafe_read_in_progress.load()) {
+            // If we were in the middle of an unsafe read, jump back
+            unsafe_read_in_progress.store(false);
+            longjmp(jump_buffer, 1);
+        } else {
+              // Chain to the previous handler
+              struct sigaction* old_action = (sig == SIGSEGV) ? &old_sigsegv_action : &old_sigbus_action;
+              if (old_action->sa_flags & SA_SIGINFO) {
+                  old_action->sa_sigaction(sig, info, context);
+              } else if (old_action->sa_handler != SIG_IGN && old_action->sa_handler != SIG_DFL) {
+                  old_action->sa_handler(sig);
+                signal(sig, SIG_DFL);
+                raise(sig);
+            }
+        }
+    }
+
+public:
+    // Initialize the signal handler
+    static bool initialize() {
+        struct sigaction action;
+        memset(&action, 0, sizeof(action));
+          action.sa_sigaction = segfault_handler;
+          action.sa_flags = SA_SIGINFO;
+
+          if (sigaction(SIGSEGV, &action, &old_sigsegv_action) != 0) {
+              return false;
+          }
+
+          return (sigaction(SIGBUS, &action, &old_sigbus_action) == 0);
+    }
+
+    // Restore the original signal handler
+    static void cleanup() {
+        sigaction(SIGSEGV, &old_sigsegv_action, nullptr);
+        sigaction(SIGBUS, &old_sigbus_action, nullptr);
+    }
+
+    // Try to safely copy memory from src to dst of size bytes
+    // Returns true if successful, false if a segfault occurred
+    static bool read(void *dst, const void *src, size_t size) {
+        if (setjmp(jump_buffer) == 0) {
+            // First time through, try the read
+            unsafe_read_in_progress.store(true);
+            memcpy(dst, src, size);
+            unsafe_read_in_progress.store(false);
+            return true;
+        } else {
+            // We got here from longjmp after a segfault
+            return false;
+        }
+    }
+};
+
 class VmReader
 {
     void *buffer{nullptr};
@@ -70,14 +139,22 @@ class VmReader
             close(fd);
             fd = -1;
 
-            // Create the temporary file
-            std::string tmpfile = tmp_dir + tmp_suffix;
-            fd = mkstemp(tmpfile.data());
-            if (fd == -1)
+              // Create the temporary file
+              std::string template_path = tmp_dir + tmp_suffix;
+              char template_buf[PATH_MAX];
+              strncpy(template_buf, template_path.c_str(), PATH_MAX - 1);
+              template_buf[PATH_MAX - 1] = '\0';
+
+              fd = mkstemp(template_buf);
+              if (fd == -1)
+                  continue;
                 continue;
 
-            // Unlink might fail if delete is blocked on the VFS, but currently no action is taken
-            unlink(tmpfile.data());
+              // Unlink the file to ensure it's removed when closed
+              if (unlink(template_buf) != 0) {
+                  // Log warning but continue
+                  std::cerr << "Warning: Failed to unlink temporary file" << std::endl;
+              }
 
             // Make sure we have enough size
             if (ftruncate(fd, new_sz) == -1)
@@ -112,21 +189,25 @@ class VmReader
     }
 
 public:
-    static VmReader *get_instance()
-    {
-        if (instance == nullptr)
-        {
-            try
-            {
-                instance = new VmReader(1024 * 1024); // A megabyte?
-            }
-            catch (std::exception &e)
-            {
-                std::cerr << "Failed to initialize VmReader: " << e.what() << std::endl;
-            }
-        }
-        return instance;
-    }
+      static VmReader *get_instance()
+      {
+          if (instance == nullptr)
+          {
+              static std::once_flag init_flag;
+              std::call_once(init_flag, []() {
+                  try
+                  {
+                      auto temp = new VmReader(1024 * 1024); // A megabyte?
+                      instance = temp;
+                  }
+                  catch (std::exception &e)
+                  {
+                      std::cerr << "Failed to initialize VmReader: " << e.what() << std::endl;
+                  }
+              });
+          }
+          return instance;
+      }
 
     ssize_t safe_copy(pid_t pid,
                       const struct iovec *local_iov, unsigned long liovcnt,
@@ -159,11 +240,14 @@ public:
             }
         }
 
-        ssize_t ret = pwritev(fd, remote_iov, riovcnt, 0);
-        if (ret == -1)
-        {
-            return ret;
-        }
+          ssize_t ret = pwritev(fd, remote_iov, riovcnt, 0);
+          if (ret == -1)
+          {
+              // Store error details for debugging
+              int err = errno;
+              std::cerr << "pwritev failed: " << strerror(err) << " (errno=" << err << ")" << std::endl;
+              return -1;
+          }
 
         // Copy the data from the buffer to the remote process
         memcpy(local_iov[0].iov_base, buffer, local_iov[0].iov_len);
@@ -194,13 +278,49 @@ inline bool read_process_vm_init()
 }
 
 inline ssize_t vmreader_safe_copy(pid_t pid,
-                           const struct iovec *local_iov, unsigned long liovcnt,
-                           const struct iovec *remote_iov, unsigned long riovcnt, unsigned long flags)
+                             const struct iovec *local_iov, unsigned long liovcnt,
+                             const struct iovec *remote_iov, unsigned long riovcnt, unsigned long flags)
 {
     auto reader = VmReader::get_instance();
     if (!reader)
         return 0;
     return reader->safe_copy(pid, local_iov, liovcnt, remote_iov, riovcnt, flags);
+}
+
+inline ssize_t trappedvmreader_safe_copy(pid_t pid,
+                             const struct iovec *local_iov, unsigned long liovcnt,
+                             const struct iovec *remote_iov, unsigned long riovcnt, unsigned long flags)
+{
+    // We only support one iovec for now
+    if (liovcnt != 1 || riovcnt != 1) {
+        return 0;
+    }
+
+    (void)pid;  // Unused parameter
+    (void)flags;  // Unused parameter
+
+    // Try to use TrappedVmReader to copy the memory
+    bool success = TrappedVmReader::read(
+        local_iov[0].iov_base,
+        remote_iov[0].iov_base,
+        std::min(local_iov[0].iov_len, remote_iov[0].iov_len)
+    );
+
+    if (success) {
+        return std::min(local_iov[0].iov_len, remote_iov[0].iov_len);
+    } else {
+        return 0;
+    }
+}
+
+static inline bool check_process_vm_readv()
+{
+    char src[128];
+    char dst[128];
+    struct iovec iov_dst = {dst, sizeof(dst)};
+    struct iovec iov_src = {src, sizeof(src)};
+    return sizeof(src) == process_vm_readv(getpid(), &iov_dst, 1, &iov_src, 1, 0);
+
 }
 
 /**
@@ -219,34 +339,37 @@ __attribute__((constructor)) inline void init_safe_copy()
     }
 
     // Check to see that process_vm_readv works, unless it's overridden
-    const char force_override_str[] = "ECHION_ALT_VM_READ_FORCE";
-    const std::array<std::string, 6> truthy_values = {"1", "true", "yes", "on", "enable", "enabled"};
-    const char *force_override = std::getenv(force_override_str);
-    if (!force_override || std::find(truthy_values.begin(), truthy_values.end(), force_override) == truthy_values.end())
-    {
-        struct iovec iov_dst = {dst, sizeof(dst)};
-        struct iovec iov_src = {src, sizeof(src)};
-        ssize_t result = process_vm_readv(getpid(), &iov_dst, 1, &iov_src, 1, 0);
+    const char vm_read_mode_key[] = "ECHION_VM_READ_MODE";
+    const char *vm_read_mode = std::getenv(vm_read_mode_key);
+    std::string mode = (vm_read_mode != nullptr) ? vm_read_mode : ""; // default to safe copy
+    std::transform(mode.begin(), mode.end(), mode.begin(), [](char c){ return std::tolower(c); });
 
-        // If we succeed, then use process_vm_readv
-        if (result == sizeof(src))
-        {
+    // By default, use safe copy
+    safe_copy = vmreader_safe_copy;
+
+    if (mode == "" || mode == "vm_read") {
+        if (check_process_vm_readv()) {
             safe_copy = process_vm_readv;
             return;
+        }
+    } else if (mode == "fast" || mode == "trap") {
+        // Initialize the TrappedVmReader signal handlers
+        if (TrappedVmReader::initialize()) {
+            safe_copy = trappedvmreader_safe_copy;
+            return;
+        } else {
+            fprintf(stderr, "Failed to initialize TrappedVmReader, falling back to default\n");
         }
     }
 
     // Else, we have to setup the writev method
-    if (!read_process_vm_init())
-    {
+    if (!read_process_vm_init()) {
         // std::cerr might not have been fully initialized at this point, so use
         // fprintf instead.
-        fprintf(stderr, "Failed to initialize all safe copy interfaces\n");
+        fprintf(stderr, "Failed to initialize safe copy interfaces\n");
         failed_safe_copy = true;
         return;
     }
-
-    safe_copy = vmreader_safe_copy;
 }
 #endif
 


### PR DESCRIPTION
This PR changes a few things

1. Adds a new sigtrap VM reader mode
2. Changes the semantics, interface, and naming of the VM reader override
3. Propagates those changes to the bootstrap init and the tests

Broadly speaking, here's what the sigtrap handler does

1. Sets up a signal handler for both SIGBUS and SIGSEGV (bad addressing can raise either)
2. Whenever a memory read is about to happen, register the read.  Currently assumes single-threaded operation, which is consistent with the echion sampling strategy
3. If the signal trap doesn't fire--great!  This is the typical case
4. If the signal trap fires *and* the fault is within the request pre-registered with the system, resume execution and pass `false` to the vmreader infrastructure
5. if the signal trap fires, but the fault is outside of that range, then it's a true fault--tear down the handler and allow the OS to re-raise the signal the normal way