### PR TITLE
perf: re-use stackchunk buffer as much as possible

### DIFF
--- a/echion/stack_chunk.h
+++ b/echion/stack_chunk.h
@@ -44,8 +44,6 @@ private:
     std::unique_ptr<char[], FreeDeleter> data = nullptr;
     size_t data_capacity = 0;
     std::unique_ptr<StackChunk> previous = nullptr;
-
-    inline StackChunk(_PyStackChunk* chunk_addr);
 };
 
 // ----------------------------------------------------------------------------

--- a/echion/stack_chunk.h
+++ b/echion/stack_chunk.h
@@ -77,7 +77,8 @@ void StackChunk::update(_PyStackChunk* chunk_addr)
     {
         try
         {
-            previous = std::unique_ptr<StackChunk>();
+            if (previous == nullptr)
+                previous = std::unique_ptr<StackChunk>();
             previous->update((_PyStackChunk*)chunk.previous);
         }
         catch (StackChunkError& e)

--- a/echion/stack_chunk.h
+++ b/echion/stack_chunk.h
@@ -27,33 +27,49 @@ public:
 class StackChunk
 {
 public:
-    inline StackChunk(PyThreadState* tstate) : StackChunk((_PyStackChunk*)tstate->datastack_chunk)
-    {
-    }
+    StackChunk() {}
 
+    inline void update(_PyStackChunk* chunk_addr);
     inline void* resolve(void* frame_addr);
 
 private:
     void* origin = NULL;
-    std::unique_ptr<char[]> data = nullptr;
+    struct FreeDeleter
+    {
+        void operator()(void* ptr) const
+        {
+            free(ptr);
+        }
+    };
+    std::unique_ptr<char[], FreeDeleter> data = nullptr;
+    size_t data_capacity = 0;
     std::unique_ptr<StackChunk> previous = nullptr;
 
     inline StackChunk(_PyStackChunk* chunk_addr);
 };
 
 // ----------------------------------------------------------------------------
-StackChunk::StackChunk(_PyStackChunk* chunk_addr)
+void StackChunk::update(_PyStackChunk* chunk_addr)
 {
     _PyStackChunk chunk;
 
-    // Copy the chunk header first
     if (copy_type(chunk_addr, chunk))
         throw StackChunkError();
 
-    origin = chunk_addr;
-    data = std::make_unique<char[]>(chunk.size);
+    // if data_size is not enough, reallocate
+    if (chunk.size > data_capacity)
+    {
+        data_capacity = chunk.size;
+        char* new_data = (char*)realloc(data.get(), data_capacity);
+        if (!new_data)
+        {
+            throw StackChunkError();
+        }
+        data.release();  // Release the old pointer before resetting
+        data.reset(new_data);
+    }
 
-    // Copy the full chunk
+    // Copy the data up until the size of the chunk
     if (copy_generic(chunk_addr, data.get(), chunk.size))
         throw StackChunkError();
 
@@ -61,7 +77,8 @@ StackChunk::StackChunk(_PyStackChunk* chunk_addr)
     {
         try
         {
-            previous = std::unique_ptr<StackChunk>{new StackChunk((_PyStackChunk*)chunk.previous)};
+            previous = std::unique_ptr<StackChunk>();
+            previous->update((_PyStackChunk*)chunk.previous);
         }
         catch (StackChunkError& e)
         {

--- a/echion/stack_chunk.h
+++ b/echion/stack_chunk.h
@@ -76,7 +76,7 @@ void StackChunk::update(_PyStackChunk* chunk_addr)
         try
         {
             if (previous == nullptr)
-                previous = std::unique_ptr<StackChunk>();
+                previous = std::make_unique<StackChunk>();
             previous->update((_PyStackChunk*)chunk.previous);
         }
         catch (StackChunkError& e)

--- a/echion/stacks.h
+++ b/echion/stacks.h
@@ -195,7 +195,11 @@ static void unwind_python_stack(PyThreadState* tstate, FrameStack& stack)
 #if PY_VERSION_HEX >= 0x030b0000
     try
     {
-        stack_chunk = std::make_unique<StackChunk>(tstate);
+        if (stack_chunk == nullptr)
+        {
+            stack_chunk = std::make_unique<StackChunk>();
+        }
+        stack_chunk->update((_PyStackChunk*)tstate->datastack_chunk);
     }
     catch (StackChunkError& e)
     {
@@ -226,7 +230,11 @@ static void unwind_python_stack_unsafe(PyThreadState* tstate, FrameStack& stack)
 #if PY_VERSION_HEX >= 0x030b0000
     try
     {
-        stack_chunk = std::make_unique<StackChunk>(tstate);
+        if (stack_chunk == nullptr)
+        {
+            stack_chunk = std::make_unique<StackChunk>();
+        }
+        stack_chunk->update((_PyStackChunk*)tstate->datastack_chunk);
     }
     catch (StackChunkError& e)
     {


### PR DESCRIPTION
This PR saves roughly 160ms per minute from stack v2 on a customer provided test environment, by avoiding frequent memory allocations/frees for `StackChunk`. 

SxS comparison

<img width="1347" alt="Screenshot 2025-04-14 at 7 38 46 PM" src="https://github.com/user-attachments/assets/805c75c6-38f5-45c9-b9ff-bef74a5d2b50" />

`StackChunk` holds data stack from the profiled Python thread. It basically is a linked list of temporary buffers (`char[]`). Echion used to allocate and free whole data structure for every thread for every sampling interval. This PR instead reallocates the buffers when more space is needed and avoid such behavior.

One caveat is that the amount of memory that we use for `StackChunk` could increase over time, if program being profiled somehow results in deeper and deeper Python stack traces over time. 

Before 
<img width="872" alt="Screenshot 2025-04-14 at 7 41 59 PM" src="https://github.com/user-attachments/assets/eaf63fce-3f0e-47e4-87c4-f1ca0e6bd8d0" />

After
<img width="870" alt="Screenshot 2025-04-14 at 7 42 05 PM" src="https://github.com/user-attachments/assets/1379eb5a-98de-40af-8279-0094fd25d78a" />


Another thing to note is that it drastically reduces
- number of allocations (5724 -> 355)
- amount of allocated memory (2.84GiB -> 178 MiB)

<img width="1341" alt="Screenshot 2025-04-14 at 7 40 46 PM" src="https://github.com/user-attachments/assets/3bf5a03c-fb7e-46f8-96bc-b8c0e1b84b7b" />
<img width="1345" alt="Screenshot 2025-04-14 at 7 40 24 PM" src="https://github.com/user-attachments/assets/9eed7794-3522-470c-ada3-0dffd18d9715" />

