### PR TITLE
fix: increment count only when frame was successfully created and pushed

### DIFF
--- a/echion/stacks.h
+++ b/echion/stacks.h
@@ -120,8 +120,6 @@ static size_t unwind_frame(PyObject* frame_addr, FrameStack& stack)
         if (seen_frames.find(current_frame_addr) != seen_frames.end())
             break;
 
-        count++;
-
         seen_frames.insert(current_frame_addr);
 
         try
@@ -139,6 +137,8 @@ static size_t unwind_frame(PyObject* frame_addr, FrameStack& stack)
         {
             break;
         }
+
+        count++;
     }
 
     return count;


### PR DESCRIPTION
`ThreadInfo::unwind_tasks()` calls `task.unwind(*stack)` to unwind the frames from a task, which calls into `unwind_frame()` in `stacks.h` 

`unwind_frame()` increments `count` variable whenever it sees a frame that hasn't been seen, and then tries to create a `Frame` object and push it into `stack` variable. However, if it fails to create the `Frame` object, the function would return `count` which is greater than the number of `Frame` objects in the `stack`. 

Then, `ThreadInfo::unwind_tasks()` calls `pop_back()` on the `stack` for `count` number of times. This could lead to an undefined behavior and crash if `unwind_frame()` has returned a number larger than the actual number of elements in the `stack`.