### PR TITLE
fix: 3.11 and 3.12 uses datastack chunk for frame address resolution

### DIFF
--- a/echion/frame.cc
+++ b/echion/frame.cc
@@ -308,7 +308,8 @@ Frame& Frame::read(PyObject* frame_addr, PyObject** prev_addr)
     {
         throw Frame::Error();
     }
-#else   // PY_VERSION_HEX < 0x030d0000 and PY_VERSION_HEX >= 0x030b0000
+#else   // PY_VERSION_HEX < 0x030d0000
+    // Code Specific to Python < 3.13 and >= 3.11
     auto resolved_addr =
         stack_chunk ? reinterpret_cast<_PyInterpreterFrame*>(stack_chunk->resolve(frame_addr))
                     : frame_addr;
@@ -324,7 +325,7 @@ Frame& Frame::read(PyObject* frame_addr, PyObject** prev_addr)
         }
         frame_addr = &iframe;
     }
-#endif  // PY_VERSION_HEX >= 0x030b0000
+#endif  // PY_VERSION_HEX >= 0x030d0000
 
     // We cannot use _PyInterpreterFrame_LASTI because _PyCode_CODE reads
     // from the code object.
@@ -345,14 +346,14 @@ Frame& Frame::read(PyObject* frame_addr, PyObject** prev_addr)
     {
 #if PY_VERSION_HEX >= 0x030c0000
         frame.is_entry = (frame_addr->owner == FRAME_OWNED_BY_CSTACK);  // Shim frame
-#else
+#else   // PY_VERSION_HEX < 0x030c0000
         frame.is_entry = frame_addr->is_entry;
-#endif
+#endif  // PY_VERSION_HEX >= 0x030c0000
     }
 
     *prev_addr = &frame == &INVALID_FRAME ? NULL : frame_addr->previous;
 
-#else  // Python < 3.11
+#else   // PY_VERSION_HEX < 0x030b0000
     // Unwind the stack from leaf to root and store it in a stack. This way we
     // can print it from root to leaf.
     PyFrameObject py_frame;
@@ -363,7 +364,7 @@ Frame& Frame::read(PyObject* frame_addr, PyObject** prev_addr)
     auto& frame = Frame::get(py_frame.f_code, py_frame.f_lasti);
 
     *prev_addr = (&frame == &INVALID_FRAME) ? NULL : reinterpret_cast<PyObject*>(py_frame.f_back);
-#endif
+#endif  // PY_VERSION_HEX < 0x030b0000
 
     return frame;
 }

--- a/echion/frame.cc
+++ b/echion/frame.cc
@@ -336,18 +336,17 @@ Frame& Frame::read(PyObject* frame_addr, PyObject** prev_addr)
         offsetof(PyCodeObject, co_code_adaptive) / sizeof(_Py_CODEUNIT);
     auto& frame = Frame::get(reinterpret_cast<PyCodeObject*>(frame_addr->f_executable), lasti);
 #else
-        const int lasti =
-            (static_cast<int>(
-                (frame_addr->prev_instr - reinterpret_cast<_Py_CODEUNIT*>((frame_addr->f_code))))) -
-            offsetof(PyCodeObject, co_code_adaptive) / sizeof(_Py_CODEUNIT);
-        auto& frame = Frame::get(frame_addr->f_code, lasti);
+    const int lasti = (static_cast<int>((frame_addr->prev_instr -
+                                         reinterpret_cast<_Py_CODEUNIT*>((frame_addr->f_code))))) -
+                      offsetof(PyCodeObject, co_code_adaptive) / sizeof(_Py_CODEUNIT);
+    auto& frame = Frame::get(frame_addr->f_code, lasti);
 #endif  // PY_VERSION_HEX >= 0x030d0000
     if (&frame != &INVALID_FRAME)
     {
 #if PY_VERSION_HEX >= 0x030c0000
         frame.is_entry = (frame_addr->owner == FRAME_OWNED_BY_CSTACK);  // Shim frame
 #else
-            frame.is_entry = frame_addr->is_entry;
+        frame.is_entry = frame_addr->is_entry;
 #endif
     }
 

--- a/echion/frame.cc
+++ b/echion/frame.cc
@@ -364,7 +364,7 @@ Frame& Frame::read(PyObject* frame_addr, PyObject** prev_addr)
     auto& frame = Frame::get(py_frame.f_code, py_frame.f_lasti);
 
     *prev_addr = (&frame == &INVALID_FRAME) ? NULL : reinterpret_cast<PyObject*>(py_frame.f_back);
-#endif  // PY_VERSION_HEX < 0x030b0000
+#endif  // PY_VERSION_HEX >= 0x030b0000
 
     return frame;
 }

--- a/echion/mirrors.h
+++ b/echion/mirrors.h
@@ -102,7 +102,7 @@ MirrorDict::MirrorDict(PyObject* dict_addr)
     if (copy_type(dict.ma_keys, keys))
         throw MirrorError();
 
-        // Compute the full dictionary data size
+    // Compute the full dictionary data size
 #if PY_VERSION_HEX >= 0x030b0000
     size_t entry_size =
         keys.dk_kind == DICT_KEYS_UNICODE ? sizeof(PyDictUnicodeEntry) : sizeof(PyDictKeyEntry);

--- a/echion/mirrors.h
+++ b/echion/mirrors.h
@@ -102,7 +102,7 @@ MirrorDict::MirrorDict(PyObject* dict_addr)
     if (copy_type(dict.ma_keys, keys))
         throw MirrorError();
 
-    // Compute the full dictionary data size
+        // Compute the full dictionary data size
 #if PY_VERSION_HEX >= 0x030b0000
     size_t entry_size =
         keys.dk_kind == DICT_KEYS_UNICODE ? sizeof(PyDictUnicodeEntry) : sizeof(PyDictKeyEntry);


### PR DESCRIPTION
Noticed that 3.11 showed too many `process_vm_readv` calls, coming from `Frame::read`, which should have been resolved using `stack_chunk` for most cases. See the red box in below image. 

![Screenshot 2025-04-17 at 4 32 34 PM](https://github.com/user-attachments/assets/5c92bce0-3500-461b-b067-4720ccf5f941)


While implementing stack chunk logic for 3.13 in #88, this wasn't properly addressed. So this is reclaiming what was initially introduced by #74 and accidentally removed by #88. 

<img width="1345" alt="image" src="https://github.com/user-attachments/assets/dacb920e-b19d-44b1-93a4-cf07ad43615d" />

All tests passed on (https://github.com/DataDog/dd-trace-py/pull/13230)