### PR TITLE
fix: use larger mojo reference key

### DIFF
--- a/echion/frame.cc
+++ b/echion/frame.cc
@@ -238,8 +238,7 @@ void Frame::infer_location(PyCodeObject* code_obj, int lasti)
 // ------------------------------------------------------------------------
 Frame::Key Frame::key(PyCodeObject* code, int lasti)
 {
-    return ((static_cast<uintptr_t>(((reinterpret_cast<uintptr_t>(code)) & MOJO_INT32)) << 16) |
-            lasti);
+    return ((static_cast<uintptr_t>(((reinterpret_cast<uintptr_t>(code)))) << 16) | lasti);
 }
 
 // ----------------------------------------------------------------------------

--- a/echion/mojo.h
+++ b/echion/mojo.h
@@ -36,6 +36,3 @@ using mojo_int_t = long long;
 using mojo_uint_t = unsigned long long;
 using mojo_ref_t = unsigned long long;
 #endif
-
-// Bitmask to ensure that we encode at most 4 bytes for an integer.
-#define MOJO_INT32 ((mojo_ref_t)(1 << (6 + 7 * 3)) - 1)

--- a/echion/render.h
+++ b/echion/render.h
@@ -152,7 +152,7 @@ class MojoRenderer : public RendererInterface
     }
     void inline ref(mojo_ref_t value)
     {
-        integer(MOJO_INT32 & value);
+        integer(value);
     }
     void inline integer(mojo_int_t n)
     {


### PR DESCRIPTION
We make the bitmask for mojo references larger to avoid potential reference collisions when parsing the generated data.