### PR TITLE
refactor: retain task metadata

### DIFF
--- a/echion/greenlets.h
+++ b/echion/greenlets.h
@@ -91,6 +91,6 @@ inline std::mutex greenlet_info_map_lock;
 
 // ----------------------------------------------------------------------------
 
-inline std::vector<std::unique_ptr<FrameStack>> current_greenlets;
+inline std::vector<std::unique_ptr<StackInfo>> current_greenlets;
 
 // ----------------------------------------------------------------------------

--- a/echion/render.h
+++ b/echion/render.h
@@ -46,7 +46,7 @@ public:
     virtual void render_thread_begin(PyThreadState* tstate, std::string_view name,
                                      microsecond_t cpu_time, uintptr_t thread_id,
                                      unsigned long native_id) = 0;
-    virtual void render_task_begin() = 0;
+    virtual void render_task_begin(std::string task_name, bool on_cpu) = 0;
     virtual void render_stack_begin(long long pid, long long iid,
                                     const std::string& thread_name) = 0;
     virtual void render_frame(Frame& frame) = 0;
@@ -117,7 +117,7 @@ public:
     {
         *output << "    🧵 " << name << ":" << std::endl;
     }
-    void render_task_begin() override {}
+    void render_task_begin(std::string task_name, bool on_cpu) override {}
     void render_stack_begin(long long, long long, const std::string&) override {}
     void render_message(std::string_view msg) override
     {
@@ -312,7 +312,7 @@ public:
     void render_message(std::string_view msg) override {};
     void render_thread_begin(PyThreadState* tstate, std::string_view name, microsecond_t cpu_time,
                              uintptr_t thread_id, unsigned long native_id) override {};
-    void render_task_begin() override {};
+    void render_task_begin(std::string task_name, bool on_cpu) override {};
     void render_stack_begin(long long pid, long long iid, const std::string& name) override
     {
         stack(pid, iid, name);
@@ -434,9 +434,9 @@ public:
         getActiveRenderer()->render_thread_begin(tstate, name, cpu_time, thread_id, native_id);
     }
 
-    void render_task_begin()
+    void render_task_begin(std::string task_name, bool on_cpu)
     {
-        getActiveRenderer()->render_task_begin();
+        getActiveRenderer()->render_task_begin(task_name, on_cpu);
     }
 
     void render_stack_begin(long long pid, long long iid, const std::string& thread_name)

--- a/echion/stacks.h
+++ b/echion/stacks.h
@@ -320,6 +320,17 @@ static void interleave_stacks()
 }
 
 // ----------------------------------------------------------------------------
+class StackInfo
+{
+public:
+    StringTable::Key task_name;
+    bool on_cpu;
+    FrameStack stack;
+
+    StackInfo(StringTable::Key task_name, bool on_cpu) : task_name(task_name), on_cpu(on_cpu) {}
+};
+
+// ----------------------------------------------------------------------------
 // This table is used to store entire stacks and index them by key. This is
 // used when profiling memory events to account for deallocations.
 class StackTable

--- a/echion/tasks.h
+++ b/echion/tasks.h
@@ -276,7 +276,7 @@ std::vector<TaskInfo::Ptr> get_all_tasks(PyObject* loop)
 
 // ----------------------------------------------------------------------------
 
-inline std::vector<std::unique_ptr<FrameStack>> current_tasks;
+inline std::vector<std::unique_ptr<StackInfo>> current_tasks;
 
 // ----------------------------------------------------------------------------
 


### PR DESCRIPTION
We refactor the task stack collection logic to include task metadata, such as the leaf task name and the on-CPU status. This information can then be passed on to the renderer to make more informed decisions on how to handle the collected stacks.