### PR TITLE
chore: make string table thread-safe

### DIFF
--- a/echion/strings.h
+++ b/echion/strings.h
@@ -93,6 +93,8 @@ public:
     // Python string object
     inline Key key(PyObject* s)
     {
+        const std::lock_guard<std::mutex> lock(table_lock);
+
         auto k = (Key)s;
 
         if (this->find(k) == this->end())
@@ -128,6 +130,8 @@ public:
     // Python string object
     inline Key key_unsafe(PyObject* s)
     {
+        const std::lock_guard<std::mutex> lock(table_lock);
+
         auto k = (Key)s;
 
         if (this->find(k) == this->end())
@@ -150,6 +154,8 @@ public:
     // Native filename by program counter
     inline Key key(unw_word_t pc)
     {
+        const std::lock_guard<std::mutex> lock(table_lock);
+
         auto k = (Key)pc;
 
         if (this->find(k) == this->end())
@@ -173,6 +179,8 @@ public:
     // Native scope name by unwinding cursor
     inline Key key(unw_cursor_t& cursor)
     {
+        const std::lock_guard<std::mutex> lock(table_lock);
+
         unw_proc_info_t pi;
         if ((unw_get_proc_info(&cursor, &pi)))
             throw Error();
@@ -211,6 +219,8 @@ public:
 
     inline std::string& lookup(Key key)
     {
+        const std::lock_guard<std::mutex> lock(table_lock);
+
         auto it = this->find(key);
         if (it == this->end())
             throw LookupError();
@@ -224,6 +234,9 @@ public:
         this->emplace(INVALID, "<invalid>");
         this->emplace(UNKNOWN, "<unknown>");
     };
+
+private:
+    std::mutex table_lock;
 };
 
 // We make this a reference to a heap-allocated object so that we can avoid


### PR DESCRIPTION
We make the string table thread-safe by locking when calling its read/write methods.