### PR TITLE
Avoids UB on `python_stack` by using unsigned types with underflow check

### DIFF
--- a/echion/threads.h
+++ b/echion/threads.h
@@ -255,7 +255,7 @@ void ThreadInfo::unwind_tasks()
 
                 // Instead we get part of the thread stack
                 FrameStack temp_stack;
-                ssize_t nframes = python_stack.size() - stack_size + 1;
+                ssize_t nframes = python_stack.size() - stack_size;
                 for (ssize_t i = 0; i < nframes; i++)
                 {
                     auto python_frame = python_stack.front();

--- a/echion/threads.h
+++ b/echion/threads.h
@@ -244,19 +244,20 @@ void ThreadInfo::unwind_tasks()
         {
             auto& task = current_task.get();
 
-            int stack_size = task.unwind(stack);
+            size_t stack_size = task.unwind(stack);
 
             if (on_cpu)
             {
                 // Undo the stack unwinding
                 // TODO[perf]: not super-efficient :(
-                for (int i = 0; i < stack_size; i++)
+                for (size_t i = 0; i < stack_size; i++)
                     stack.pop_back();
 
                 // Instead we get part of the thread stack
                 FrameStack temp_stack;
-                ssize_t nframes = python_stack.size() - stack_size;
-                for (ssize_t i = 0; i < nframes; i++)
+                size_t nframes =
+                    (python_stack.size() > stack_size) ? python_stack.size() - stack_size : 0;
+                for (size_t i = 0; i < nframes; i++)
                 {
                     auto python_frame = python_stack.front();
                     temp_stack.push_front(python_frame);


### PR DESCRIPTION
If we comment out `unwind_frame()` function body except for `int count = 0; and return count;` and run
```
echion --cpu -o profiles/task.mojo ~/.pyenv/versions/3.13.3/bin/python3.13 -m tests.target_gather
```
with `target_gather.py` from https://gist.github.com/taegyunkim/df3ddc68731668b7d2fe33e44632037a

We get the following stack traceback from coredump 
```
#2  0x00007b884363a9a6 in std::deque<std::reference_wrapper<Frame>, std::allocator<std::reference_wrapper<Frame> > >::push_back (this=0x7b883c0087f0, __x=...) at /usr/include/c++/11/bits/stl_deque.h:1501
#3  0x00007b884362d235 in ThreadInfo::unwind_tasks (this=0x63d29b0bc790) at ./echion/threads.h:303
#4  0x00007b884362c75c in ThreadInfo::unwind (this=0x63d29b0bc790, tstate=0x7b884305fe50) at ./echion/threads.h:170
No locals.
#5  0x00007b884362daa9 in ThreadInfo::sample (this=0x63d29b0bc790, iid=0, tstate=0x7b884305fe50, delta=1000) at ./echion/threads.h:401
No locals.
#6  0x00007b884362f53e in operator() (__closure=0x7b884305ffd0, tstate=0x7b884305fe50, thread=...) at echion/coremodule.cc:21
```
[echion_traceback (1).log](https://github.com/user-attachments/files/21584898/echion_traceback.1.log)

This happens as we call `front()` and `pop()` on an empty `python_stack`. 

To avoid such UBs, we 
1) remove `+1` from calculation 
2) Use unsigned types with bounds check