### PR TITLE
fix: check for null chunk ptr

### DIFF
--- a/echion/stack_chunk.h
+++ b/echion/stack_chunk.h
@@ -56,7 +56,7 @@ void StackChunk::update(_PyStackChunk* chunk_addr)
 
     origin = chunk_addr;
     // if data_size is not enough, reallocate
-    if (chunk.size > data_capacity)
+    if (chunk.size > data_capacity || data.get() == nullptr)
     {
         data_capacity = chunk.size;
         char* new_data = (char*)realloc(data.get(), data_capacity);

--- a/echion/stack_chunk.h
+++ b/echion/stack_chunk.h
@@ -92,6 +92,11 @@ void* StackChunk::resolve(void* address)
 {
     _PyStackChunk* chunk = (_PyStackChunk*)data.get();
 
+    if (chunk == nullptr)
+    {
+        return address;
+    }
+
     // Check if this chunk contains the address
     if (address >= origin && address < (char*)origin + chunk->size)
         return (char*)chunk + ((char*)address - (char*)origin);


### PR DESCRIPTION
When `StackChunk` is constructed, it doesn't initialize the backing `data` and `data_capacity` is 0. 
It's initialized only when `if (chunk.size > data_capacity)` holds, but then if `chunk.size` is 0 too for some reason, we avoid allocating memory for `data` and we could in theory can get null pointer there. 

Maybe this could happen when the `_PyStackChunk` is being initialized and has not yet updated its `size` field. 

So we'd need to allocate some memory when `data.get()` is a nullptr