### PR TITLE
fix: use std::string::data() instead of c_str()

### DIFF
--- a/echion/strings.h
+++ b/echion/strings.h
@@ -73,7 +73,7 @@ static std::string pyunicode_to_utf8(PyObject* str_addr)
         throw StringError();
 
     auto dest = std::string(size, '\0');
-    if (copy_generic(data, dest.c_str(), size))
+    if (copy_generic(data, dest.data(), size))
         throw StringError();
 
     return dest;


### PR DESCRIPTION
`c_str` returns a non-modifiable standard C character array version of the string
(public member function)


const CharT* c_str() const; |   | (noexcept since C++11)(constexpr since C++20)
-- | -- | --

https://en.cppreference.com/w/cpp/string/basic_string/c_str.html


`data` returns a pointer to the first character of a string
(public member function)


const CharT* data() const; | (1) | (noexcept since C++11)(constexpr since C++20)
-- | -- | --
CharT* data() noexcept; | (2) | (since C++17)(constexpr since C++20)

https://en.cppreference.com/w/cpp/string/basic_string/data.html

