### PR TITLE
bug: add `set_max_frames` to `PyMethodDef`

### DIFF
--- a/echion/coremodule.cc
+++ b/echion/coremodule.cc
@@ -518,7 +518,9 @@ static PyMethodDef echion_core_methods[] = {
     {"set_native", set_native, METH_VARARGS, "Set whether to sample the native stacks"},
     {"set_where", set_where, METH_VARARGS, "Set whether to use where mode"},
     {"set_pipe_name", set_pipe_name, METH_VARARGS, "Set the pipe name"},
-    {NULL, NULL, 0, NULL} /* Sentinel */
+    {"set_max_frames", set_max_frames, METH_VARARGS, "Set the max number of frames to unwind"},
+    // Sentinel
+    {NULL, NULL, 0, NULL}
 };
 
 // ----------------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR do?

This PR adds the `set_max_frames` function to the `PyMethodDef` as it does not seem to be pushed there at the moment. 

I tried to run a modified version of `echion` that tries to call `set_max_frames` with the version currently on `main` and it results in the following.

```
% echion python3 to_run.py
Traceback (most recent call last):
  File "/home/bits/echion/env/bin/echion", line 8, in <module>
    sys.exit(main())
             ^^^^^^
  File "/home/bits/echion/echion/__main__.py", line 203, in main
    from echion.core import set_max_frames
ImportError: cannot import name 'set_max_frames' from 'echion.core' (/home/bits/echion/echion/core.cpython-311-x86_64-linux-gnu.so)
```

The same command does work after my change. 