### PR TITLE
fix: remove unneeded try/catch

### DIFF
--- a/echion/strings.h
+++ b/echion/strings.h
@@ -167,17 +167,10 @@ public:
 
         if (this->find(k) == this->end())
         {
-            try
-            {
-                char buffer[32] = {0};
-                std::snprintf(buffer, 32, "native@%p", (void*)k);
-                this->emplace(k, buffer);
-                Renderer::get().string(k, buffer);
-            }
-            catch (StringError&)
-            {
-                throw Error();
-            }
+            char buffer[32] = {0};
+            std::snprintf(buffer, 32, "native@%p", (void*)k);
+            this->emplace(k, buffer);
+            Renderer::get().string(k, buffer);
         }
 
         return k;


### PR DESCRIPTION
## What does this PR do?

This PR removes an unneeded `try` / `catch` block from the code. It's a functional no-op and I don't expect it to have any positive impact on performance.

I checked and as far as I know/can tell:
- The buffer stack allocation cannot throw
- `std::snprintf` cannot throw
- `this->emplace` may (maybe? I don't know) throw but definitely not a `StringError`, so the current `catch` wouldn't catch it 
- `Renderer::get()` and `Renderer::string` cannot throw a `StringError`

I suspect this was added to replicate what was done in `inline Key key(PyObject* s)` but this one actually needs it in case `pyunicode_to_utf8` throws.