### PR TITLE
fix: remove completed Task's name from StringTable

### DIFF
--- a/echion/strings.h
+++ b/echion/strings.h
@@ -9,6 +9,7 @@
 #include <unicodeobject.h>
 
 #include <cstdint>
+#include <mutex>
 #include <string>
 
 #ifndef UNWIND_NATIVE_DISABLE
@@ -18,6 +19,7 @@
 #endif  // UNWIND_NATIVE_DISABLE
 
 
+#include <echion/errors.h>
 #include <echion/long.h>
 #include <echion/render.h>
 #include <echion/vm.h>
@@ -220,6 +222,12 @@ public:
             return ErrorKind::LookupError;
 
         return std::ref(it->second);
+    };
+
+    inline void remove(Key key)
+    {
+        const std::lock_guard<std::mutex> lock(table_lock);
+        this->erase(key);
     };
 
     StringTable() : std::unordered_map<uintptr_t, std::string>()

--- a/echion/threads.h
+++ b/echion/threads.h
@@ -239,7 +239,7 @@ inline Result<void> ThreadInfo::unwind_tasks()
     std::unordered_set<PyObject*> parent_tasks;
     std::unordered_map<PyObject*, TaskInfo::Ref> waitee_map;  // Indexed by task origin
     std::unordered_map<PyObject*, TaskInfo::Ref> origin_map;  // Indexed by task origin
-    static std::unordered_set<PyObject*> previous_task_objects;
+    static std::unordered_map<PyObject*, StringTable::Key> previous_task_objects;
 
     auto maybe_all_tasks = get_all_tasks(reinterpret_cast<PyObject*>(asyncio_loop));
     if (!maybe_all_tasks)
@@ -267,8 +267,10 @@ inline Result<void> ThreadInfo::unwind_tasks()
         for (auto key : to_remove) {
             // Only remove the link if the Child Task previously existed; otherwise it's a Task that
             // has just been created and that wasn't in all_tasks when we took the snapshot.
-            if (previous_task_objects.find(key) != previous_task_objects.end()) {
+            if (auto it = previous_task_objects.find(key); it != previous_task_objects.end()) {
                 task_link_map.erase(key);
+                // Remove the task name from the stringtable
+                string_table.remove(it->second);
             }
         }
 
@@ -277,10 +279,10 @@ inline Result<void> ThreadInfo::unwind_tasks()
                        std::inserter(parent_tasks, parent_tasks.begin()),
                        [](const std::pair<PyObject*, PyObject*>& kv) { return kv.second; });
 
-        // Copy all Task object pointers into previous_task_objects
+        // Copy all Task object pointers (and the StringTable::Key for their name) into previous_task_objects
         previous_task_objects.clear();
         for (const auto& task : all_tasks) {
-            previous_task_objects.insert(task->origin);
+            previous_task_objects.emplace(task->origin, task->name);
         }
     }
 


### PR DESCRIPTION
## Description

https://datadoghq.atlassian.net/browse/PROF-13291

This PR updates the echion logic so that the names of `asyncio` Tasks that have completed are removed from the `StringTable` as soon as we detect relevant Tasks have completed. 

There are mostly two reasons for that:
- `StringTable::key(Task*)` really is just `reinterpret_cast<uintptr_t>(Task*)` which means we can have collisions if an address is reused by the Python runtime.
  - It sounds unlikely at first but it very probably happens, especially over long time periods (see https://datadoghq.atlassian.net/browse/PROF-13207). 
  - If an address is reused, then we will assume two completely different Tasks have the same name (the name of the first Task that ran). This means they will share the same Flame Graph (once the Profiles are aggregated), and also that it could lead to nonsensical Stacks (e.g. the Stack of the second Task under the name of the first).  
- It also technically is a memory leak... It makes sense to store certain things forever in the `StringTable` (file names, function names, etc.) but Tasks are ephemeral (although more or less long-running), so keeping the name of each Task forever is... a leak. 